### PR TITLE
fix(autoscaler): re-enable transactional-update.timer after agent install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Bug Fixes
 
+- Cluster Autoscaler nodes now re-enable `transactional-update.timer` at the end of cloud-init when `automatically_upgrade_os` is true (the default). The shared runcmd preamble disables the timer for the duration of first boot and only `terraform_data.os_upgrade_toggle` re-enabled it, which exists per `hcloud_server` and therefore never runs for autoscaler-created nodes; those nodes stayed on the snapshot's packages indefinitely and never produced the `/var/run/reboot-required` sentinel kured reboots on. Existing autoscaled nodes keep their current user-data until the autoscaler recycles them.
 - Made the generated-site contract test portable to clean GitHub Actions runners instead of requiring undeclared `rg`. CI installs Zsh and Fish and fails closed when a documented shell verifier is missing; local runs print an explicit skip when an optional shell is unavailable.
 
 ### 🔧 Changes

--- a/autoscaler-agents.tf
+++ b/autoscaler-agents.tf
@@ -230,6 +230,7 @@ data "cloudinit_config" "autoscaler_config" {
         multinetwork_transport_ipv4_enabled = local.multinetwork_transport_ipv4_enabled
         multinetwork_transport_ipv6_enabled = local.multinetwork_transport_ipv6_enabled
         tailscale_bootstrap_script          = local.tailscale_cloud_init_bootstrap_enabled ? local.tailscale_bootstrap_script_autoscaler_by_index[count.index] : ""
+        automatically_upgrade_os            = var.automatically_upgrade_os
       }
     )
   }
@@ -285,6 +286,7 @@ data "cloudinit_config" "autoscaler_config_rke2" {
         multinetwork_transport_ipv4_enabled = local.multinetwork_transport_ipv4_enabled
         multinetwork_transport_ipv6_enabled = local.multinetwork_transport_ipv6_enabled
         tailscale_bootstrap_script          = local.tailscale_cloud_init_bootstrap_enabled ? local.tailscale_bootstrap_script_autoscaler_by_index[count.index] : ""
+        automatically_upgrade_os            = var.automatically_upgrade_os
       }
     )
   }

--- a/scripts/render_harness.py
+++ b/scripts/render_harness.py
@@ -480,6 +480,7 @@ def base_render_vars() -> dict[str, Any]:
     }
 
     top_level = {
+        "automatically_upgrade_os": True,
         "cloudinit_runcmd_common": "- echo render-harness-common",
         "cloudinit_runcmd_extra": [],
         "cloudinit_write_files_common": (
@@ -1155,6 +1156,54 @@ def run_autoscaler_standard_node_ip_checks() -> None:
     )
 
 
+def run_autoscaler_os_upgrade_timer_checks() -> None:
+    label = "autoscaler OS upgrade timer cloud-init"
+    timer_command = "systemctl enable --now transactional-update.timer"
+    agent_install = "/var/pre_install/install-k8s-agent.sh"
+
+    def runcmd_for(upgrade_os: bool) -> list:
+        render_vars = base_render_vars()
+        render_vars["automatically_upgrade_os"] = upgrade_os
+        _, document = render_cloudinit_with_vars(
+            render_vars,
+            REPO_ROOT / "templates/autoscaler-cloudinit.yaml.tpl",
+        )
+        runcmd = document.get("runcmd")
+        if not isinstance(runcmd, list):
+            fail(label, f"runcmd is not a list for automatically_upgrade_os={upgrade_os}")
+        return runcmd
+
+    enabled = runcmd_for(True)
+
+    def index_of(runcmd: list, needle: str) -> int:
+        for position, item in enumerate(runcmd):
+            if isinstance(item, str) and needle in item:
+                return position
+            if isinstance(item, list) and any(needle in part for part in item):
+                return position
+        return -1
+
+    timer_index = index_of(enabled, timer_command)
+    if timer_index < 0:
+        fail(label, "autoscaler nodes never re-enable transactional-update.timer")
+    if timer_index != len(enabled) - 1:
+        fail(label, "the timer must be re-enabled by the last runcmd entry")
+
+    agent_index = index_of(enabled, agent_install)
+    if agent_index < 0:
+        fail(label, "rendered runcmd has no agent install entry")
+    if timer_index < agent_index:
+        fail(label, "re-enabling the timer must not race the Kubernetes bootstrap")
+
+    if index_of(runcmd_for(False), timer_command) >= 0:
+        fail(label, "automatically_upgrade_os = false must not re-enable the timer")
+
+    print_pass(
+        label,
+        "re-enables transactional-update.timer after the agent install, and only when automatically_upgrade_os is true",
+    )
+
+
 def run_autoscaler_tailscale_bootstrap_scope_checks() -> None:
     tailscale_vars = base_render_vars()
     tailscale_vars["tailscale_bootstrap_script"] = """set -euo pipefail
@@ -1734,6 +1783,7 @@ def main() -> int:
         run_node_annotation_cloudinit_checks(scratch)
         run_autoscaler_standard_node_ip_checks()
         run_autoscaler_tailscale_bootstrap_scope_checks()
+        run_autoscaler_os_upgrade_timer_checks()
         run_autoscaler_overlay_node_ip_checks()
         run_autoscaler_manifest_checks(scratch)
         run_kubeconfig_checks(scratch)

--- a/templates/autoscaler-cloudinit.yaml.tpl
+++ b/templates/autoscaler-cloudinit.yaml.tpl
@@ -370,3 +370,15 @@ ${indent(2, "\n${chomp(tailscale_bootstrap_script)}")}
 
 # Start the Kubernetes agent install script
 - ['/bin/bash', '/var/pre_install/install-k8s-agent.sh']
+%{if automatically_upgrade_os~}
+
+# Re-enable automatic OS updates. The shared runcmd preamble disables
+# transactional-update.timer for the duration of first boot; on host-module nodes
+# terraform_data.os_upgrade_toggle turns it back on after provisioning, but nodes created
+# by the Cluster Autoscaler have no such resource and would stay disabled forever. This
+# runs last, after the agent install, so re-enabling can no longer race the bootstrap.
+# --now is required: enable alone only creates the symlink, and the unit would not be
+# pulled in until timers.target on the next boot.
+- |
+  systemctl enable --now transactional-update.timer || true
+%{endif~}


### PR DESCRIPTION
Fixes #2266.

## Problem

With the default `automatically_upgrade_os = true`, nodes created by the Cluster
Autoscaler never enable `transactional-update.timer`. They keep the packages baked into
the snapshot, never write `/var/run/reboot-required`, and are therefore never rebooted by
kured — while static nodes on the same snapshot patch and reboot normally.

Observed on a running v3.1.0 cluster:

| node | `transactional-update.timer` | kernel | uptime |
|---|---|---|---|
| autoscaler-created | `disabled` / `inactive` | 6.19.5 | 137 h, never rebooted |
| static agent, same snapshot | `enabled` / `active` | 7.1.8 | reboots nightly |

A freshly scaled-up node arrives with the timer already disabled, so this is not drift.

## Cause

`local.cloudinit_runcmd_common` (`locals.tf:3678-3684`) unconditionally disables the timer
for the duration of first boot, which is correct — an update mid-cloud-init can race the
Kubernetes bootstrap.

That runcmd is shared by three consumers: `agents.tf:70`, `control_planes.tf:70` (both via
`modules/host`) and `autoscaler-agents.tf:222` / `:277`.

Re-enabling happens in exactly one place: `terraform_data.os_upgrade_toggle`
(`modules/host/main.tf:500-538`), keyed on `hcloud_server.server.id` (line 503). Autoscaler
nodes are not `hcloud_server` resources — `autoscaler-agents.tf:52`/`:71` hand the rendered
cloud-init to the Cluster Autoscaler as `cloudInit` — so that toggle can never run for
them and the timer stays disabled for the life of the node.

`templates/autoscaler-cloudinit.yaml.tpl` does not reference the timer at all, and
`automatically_upgrade_os` is not among the variables passed to either `templatefile` call.

## Fix

Pass `automatically_upgrade_os` into both autoscaler `templatefile` calls and re-enable the
timer as the **last** runcmd entry, after `install-k8s-agent.sh`:

```hcl
%{if automatically_upgrade_os~}
- |
  systemctl enable --now transactional-update.timer || true
%{endif~}
```

Placement is deliberate. runcmd is a single sequential shell script, and the agent is
already started by then (`autoscaler-agents.tf:219` appends a blocking
`systemctl start k3s-agent`), so re-enabling can no longer race the bootstrap.

`--now` is required: plain `enable` only creates the symlink, and the unit would not be
pulled in until `timers.target` on the next boot — which for these nodes may never come.

I also considered appending to `cloudinit_runcmd_common` at the two autoscaler call sites,
which would avoid a new template variable. It does not work: `${cloudinit_runcmd_common}`
is spliced at `templates/autoscaler-cloudinit.yaml.tpl:112`, i.e. the top of runcmd, which
puts the timer back in the middle of cloud-init — the exact race the disable prevents.

## Testing

- `terraform fmt -recursive -check`, `terraform init -backend=false`, `terraform validate`:
  clean.
- OpenTofu 1.12.5 `init -backend=false` + `validate` on a temp copy: clean.
- `uv run scripts/render_harness.py`: passes. Reverting only the template hunk makes the
  new check fail, so it is not vacuous.
- Added a regression check to the harness. `base_render_vars()` needed the new key or every
  render of this template fails, so that is part of the change. The check asserts the entry
  is last, ordered after the agent install, and absent when `automatically_upgrade_os` is
  false.
- Upgrade impact, measured against a real cluster's state by planning v3.1.0 and
  v3.1.0-plus-this-change and diffing `.resource_changes[].address`: the only delta is
  `module.kube-hetzner.terraform_data.configure_autoscaler[0]` (delete+create). No
  `hcloud_server`, volume, network, load balancer, primary IP, firewall or placement group
  appears in the plan.

## Notes

- Existing autoscaled nodes keep their current user-data until the autoscaler recycles them.
- Scope checked and deliberately not widened: the NAT router renders its own template and
  runs `debian-12`, and robot nodes use no cloud-init at all. Neither is affected.
- One residual risk worth naming: `terraform_data.autoscaled_nodes_registries`
  (`autoscaler-agents.tf:298-326`) writes `/etc/rancher/k3s/registries.yaml` over SSH after
  cloud-init. If a transactional snapshot were created in between and the node rebooted,
  that write could be lost. The window is small — with `RandomizedDelaySec=2h` the first run
  is not immediate — but it is real.
- Happy to reshape this if you would prefer the re-enable somewhere else.

<sub>Developed with AI assistance (Claude Code); I directed the change and verified fmt, validate, OpenTofu validate, the render harness and the plan-diff locally.</sub>
