### PR TITLE
fix: keep metadata service off the private network when DHCP advertises a /32 for 169.254.169.254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Bug Fixes
 
+- Kept the Hetzner metadata service reachable when the private-network DHCP server advertises a classless static route (option 121 / RFC 3442) for `169.254.169.254` via the private gateway. That path black-holes on affected networks, and because the offered route is a `/32` it beats the public default route by longest-prefix-match at any metric, so `ipv4.never-default` and `ipv4.route-metric` on the private connection could not prevent it; `hcloud-csi-node` crashlooped on `failed to fetch server ID from metadata service` and stalled the DaemonSet rollout. All node types, including autoscaler nodes, now pin the same `/32` via the public gateway at a lower metric, persisted in the public connection profile so it survives DHCP lease renewals and reboots. Nodes with no route to the public gateway are left untouched, since there metadata legitimately traverses the private network (#2268).
 - Made the generated-site contract test portable to clean GitHub Actions runners instead of requiring undeclared `rg`. CI installs Zsh and Fish and fails closed when a documented shell verifier is missing; local runs print an explicit skip when an optional shell is unavailable.
 
 ### 🔧 Changes

--- a/locals.tf
+++ b/locals.tf
@@ -3751,6 +3751,35 @@ cloudinit_runcmd_common = <<EOT
 - [sed, '-i', 's/^root:!/root:/', '/etc/shadow']
 - [systemctl, 'restart', 'sshd']
 
+# Keep the Hetzner metadata service reachable when the private-network DHCP
+# server advertises a classless static route (option 121 / RFC 3442) for
+# 169.254.169.254 via the private gateway. That path black-holes on affected
+# networks, and because the offered route is a /32 it beats the public default
+# route by longest-prefix-match at any metric - so ipv4.never-default and
+# ipv4.route-metric on the private connection cannot prevent it. Pin the same
+# /32 via the public gateway at a lower metric instead, persisted in the public
+# connection profile so it survives DHCP renewals and reboots (runcmd is
+# per-instance only). The DHCP route is deliberately left in place, since
+# deleting it would only bring it back on the next renewal. Nodes with no route
+# to the public gateway are left alone, because there metadata legitimately has
+# to traverse the private network.
+- |
+  METADATA_IP=169.254.169.254
+  PUBLIC_GW=172.31.1.1
+  METADATA_METRIC=100
+  PUB_IF=$(ip -4 route get "$PUBLIC_GW" 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "dev") {print $(i + 1); exit}}')
+  if [ -z "$PUB_IF" ]; then
+    echo "Info: no route to $PUBLIC_GW; leaving $METADATA_IP routing unchanged."
+  else
+    if systemctl is-active --quiet NetworkManager; then
+      PUB_CONN=$(nmcli -g GENERAL.CONNECTION device show "$PUB_IF" 2>/dev/null | head -1)
+      if [ -n "$PUB_CONN" ] && ! nmcli -g ipv4.routes connection show "$PUB_CONN" 2>/dev/null | grep -q "$METADATA_IP/32"; then
+        nmcli connection modify "$PUB_CONN" +ipv4.routes "$METADATA_IP/32 $PUBLIC_GW $METADATA_METRIC" >/dev/null 2>&1 || echo "Warning: could not persist the $METADATA_IP route on $PUB_CONN." >&2
+      fi
+    fi
+    ip -4 route replace "$METADATA_IP/32" via "$PUBLIC_GW" dev "$PUB_IF" metric "$METADATA_METRIC" 2>/dev/null || echo "Warning: could not pin $METADATA_IP via $PUBLIC_GW dev $PUB_IF." >&2
+  fi
+
 EOT
 
 }


### PR DESCRIPTION
Fixes #2268.

## TL;DR

- **Problem:** Hetzner's private-network DHCP now sometimes advertises `169.254.169.254/32` via the private gateway, and that path black-holes. Being a `/32` it beats the public default route by longest-prefix-match at any metric, so the existing `never-default` / `route-metric` guard cannot stop it. `hcloud-csi-driver` crashloops on `failed to fetch server ID from metadata service`.
- **Change:** one block appended to `cloudinit_runcmd_common` that pins the same `/32` via the public gateway at metric 100 and persists it in the public NM connection profile. ~30 lines, no variables, defaults, or state addresses touched; no resources recreated.
- **Why there:** `cloudinit_runcmd_common` is the only injection point shared by static control planes, static agents **and** autoscaler nodes. `preinstall_exec` only reaches static nodes, so it cannot fix autoscaled nodes — which were the ones breaking for us.
- **Deliberately:** pins rather than deletes the DHCP route (deleting invites it back on renewal); leaves `10.0.0.0/8` untouched (so not `ignore-auto-routes`); skips nodes with no public gateway, where metadata must use the private network.
- **Tested:** `fmt`/`validate`/`render_harness.py` all clean (the harness asserts both the host and autoscaler cloud-init templates still `yamldecode`), `bash -n` + `sh -n` on the rendered block, and a stubbed branch simulation covering affected / already-persisted / private-only / NM-inactive. The equivalent pin was verified on a live affected cluster.
- **Caveat:** `runcmd` is per-instance, so this only helps new or replaced nodes; already-affected nodes still need the route applied out-of-band.

---


## The real problem

Hetzner's private-network DHCP server has started advertising a classless static route (DHCP option 121 / RFC 3442) for `169.254.169.254` via the **private** gateway. That path black-holes: the gateway answers ICMP, but the metadata endpoint never responds.

Because the offered route is a `/32`, it beats `eth0`'s default route by longest-prefix-match **at any metric**. `hcloud-csi-driver` then cannot fetch its server ID at startup and crashloops, taking `csi-node-driver-registrar` with it (it waits forever on a CSI socket that is never created) and stalling the `hcloud-csi-node` rollout.

The existing `private_default_route_repair_script` cannot catch this:

- `ipv4.never-default yes` suppresses only the DHCP-supplied **default** route; a `/32` static route is not a default route.
- `ipv4.route-metric 30000` is not a tiebreaker, because metric only orders routes of *equal prefix length*.

## How it was verified

Two agent nodes in the same subnet, same DHCP server (`10.0.0.1`), created ~3 minutes apart. From `/run/NetworkManager/devices/<n>`:

```
affected (10.255.0.4):
  dhcp4.rfc3442_classless_static_routes=10.0.0.1/32 0.0.0.0 10.0.0.0/8 10.0.0.1 169.254.169.254/32 10.0.0.1

healthy  (10.255.0.5):
  dhcp4.rfc3442_classless_static_routes=10.0.0.1/32 0.0.0.0 10.0.0.0/8 10.0.0.1
```

The rollout is progressive, so it hits some nodes and not others — which reads as random, especially under autoscaling.

Per-interface reachability on the **affected** node:

| path | result |
|---|---|
| default (via eth1) | timeout |
| `curl --interface eth0` | `162833978` ✅ |
| `curl --interface eth1` | timeout |

Forcing `--interface eth1` on the **healthy** node also times out, so metadata-over-private-network is simply not served on this network — healthy nodes are fine only because they were never routed onto it. `ping 10.0.0.1` succeeds on both, so the gateway itself is up. This is what rules out a gateway fault and identifies the route as the whole cause.

## The change

One block appended to `cloudinit_runcmd_common`: detect the public interface dynamically, pin `169.254.169.254/32` via `172.31.1.1` at metric 100 (so it wins on metric at equal prefix length), persist it in the public connection profile, and apply it immediately.

Deliberate choices:

- **Pin rather than delete.** Removing the DHCP route would only bring it back on the next renewal.
- **Persist in the NM profile.** `runcmd` is per-instance only — as the neighbouring root-unlock comment in this file already notes — so a runtime-only route would not survive a kured reboot.
- **`10.0.0.0/8` untouched.** This is why the fix pins a competing `/32` instead of setting `ipv4.ignore-auto-routes` on the private connection, which would also drop the private route that pod and node traffic depend on.
- **Skipped when there is no route to the public gateway**, since private-only nodes must legitimately reach metadata over the private network.

### Why `cloudinit_runcmd_common`

It is the only injection point shared by all node types — `control_planes.tf:70`, `agents.tf:70` (both via `modules/host`), and `autoscaler-agents.tf:222,277`.

This matters: `preinstall_exec` is **not** a viable user-side workaround, because it is only reachable through `common_pre_install_k3s_commands`, which autoscaler nodes never execute. Autoscaler nodes were exactly the ones breaking in our cluster. The autoscaler template's own route handling is likewise default-route-only and runtime-only.

## Tested

- `terraform fmt -check -recursive` — clean
- `terraform init -backend=false` + `terraform validate` — Success
- `python3 scripts/render_harness.py` — exit 0, no failures. Notably it asserts both `modules/host/templates/cloudinit.yaml.tpl` and `templates/autoscaler-cloudinit.yaml.tpl` still `yamldecode`, which covers the static and autoscaler paths this block lands in.
- `bash -n` and `sh -n` on the extracted block — clean.
- Branch simulation with stubbed `ip`/`nmcli`/`systemctl`, asserting the commands actually invoked:

| scenario | result |
|---|---|
| affected node, not yet persisted | `nmcli connection modify … +ipv4.routes` **and** `ip -4 route replace` |
| already persisted | `ip -4 route replace` only — no duplicate profile entry |
| no public gateway (private-only) | nothing invoked, info message only |
| NetworkManager inactive | `ip -4 route replace` only, no crash |

- The equivalent route pin was exercised on a live affected cluster (16 nodes, k3s `v1.33.13+k3s2`, MicroOS, Flannel) as a `NET_ADMIN` DaemonSet before this PR: pinning the `/32` via the public interface restores metadata and clears the CSI crashloop, and route writes are permitted under enforcing SELinux with `NET_ADMIN` alone.

**Upgrade impact:** no resources are recreated; no variables, defaults, or state addresses change. The block is a no-op on nodes that never receive the metadata route, apart from adding one profile entry. It only takes effect on newly provisioned or replaced nodes, since `runcmd` is per-instance — existing affected nodes still need the route applied out-of-band.

## Not addressed here

Kept out to stay narrow, but worth flagging: the module makes three further metadata calls that fail **silently** on an affected node because they are wrapped in fallbacks — Tailscale hostname in `locals.tf`, `public-ipv4` in `templates/autoscaler-cloudinit.yaml.tpl`, and `instance-id` in the NAT-router templates. NAT routers are Debian-based and do not consume `cloudinit_runcmd_common`, so they are untouched by this change.

