### PR TITLE
fix: omit server-only flag from floating IP agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🐛 Bug Fixes
 
+- Fixed K3s agents with floating IPs receiving the server-only `flannel-external-ip` flag, which prevented the agent service from starting. Floating-IP agents continue to advertise `node-external-ip`.
 - Made the generated-site contract test portable to clean GitHub Actions runners instead of requiring undeclared `rg`. CI installs Zsh and Fish and fails closed when a documented shell verifier is missing; local runs print an explicit skip when an optional shell is unavailable.
 
 ### 🔧 Changes

--- a/agents.tf
+++ b/agents.tf
@@ -150,8 +150,7 @@ locals {
     local.multinetwork_overlay_enabled ? {
       node-external-ip = join(",", compact([local.multinetwork_transport_ipv4_enabled ? module.agents[k].ipv4_address : null, local.multinetwork_transport_ipv6_enabled ? module.agents[k].ipv6_address : null]))
       } : lookup(local.agent_external_ip_by_node, k, null) != null ? {
-      node-external-ip    = local.agent_external_ip_by_node[k]
-      flannel-external-ip = true
+      node-external-ip = local.agent_external_ip_by_node[k]
     } : {},
     local.disable_default_registry_endpoint_config,
     var.agent_nodes_custom_config,

--- a/scripts/render_harness.py
+++ b/scripts/render_harness.py
@@ -188,6 +188,33 @@ def normalize_hcl(source: str) -> str:
     return re.sub(r"\s+", "", source)
 
 
+def assert_agent_floating_ip_config_contract() -> None:
+    """Keep server-only Flannel flags out of generated agent config."""
+
+    agents_source = AGENTS_TF.read_text(encoding="utf-8")
+    k3s_start = agents_source.find("k3s-agent-config =")
+    rke2_start = agents_source.find("rke2-agent-config =", k3s_start)
+    if k3s_start == -1 or rke2_start == -1:
+        fail("agent floating IP config", "could not isolate the K3s agent config local")
+
+    k3s_source = normalize_hcl(agents_source[k3s_start:rke2_start])
+    if "flannel-external-ip" in k3s_source:
+        fail(
+            "agent floating IP config",
+            "K3s agents must not receive the server-only flannel-external-ip flag",
+        )
+    if "node-external-ip=local.agent_external_ip_by_node[k]" not in k3s_source:
+        fail(
+            "agent floating IP config",
+            "floating-IP agents must retain their node-external-ip setting",
+        )
+
+    print_pass(
+        "agent floating IP config",
+        "retains node-external-ip without the server-only Flannel flag",
+    )
+
+
 def assert_agent_private_ipv4_contract(scratch: "TerraformScratch") -> None:
     """Protect v2 identity, external-network opt-out, and shared uniqueness."""
 
@@ -1716,6 +1743,7 @@ def main() -> int:
     try:
         scratch = TerraformScratch(temp_dir, base_render_vars())
         assert_addon_default_versions()
+        assert_agent_floating_ip_config_contract()
         assert_agent_private_ipv4_contract(scratch)
         assert_opensuse_ssh_cloudinit_contract()
         assert_baked_selinux_package_contract()


### PR DESCRIPTION
## Summary

Prevent K3s agent nodes with Hetzner Floating IPs from receiving the server-only `flannel-external-ip` configuration flag.

## Problem

When an agent nodepool has `floating_ip = true`, kube-hetzner currently generates:

```yaml
node-external-ip: <floating-ip>
flannel-external-ip: true
```

However, `flannel-external-ip` is a server-only, cluster-wide K3s option. K3s agents must receive only `node-external-ip`; passing `flannel-external-ip` to an agent causes startup to fail with an unknown-flag error. The issue was reproduced on v1.34.10+k3s1, but is not specific to that release.

```text
Error: flag provided but not defined: -flannel-external-ip
```

This prevents newly created or reprovisioned Floating-IP agents from joining the cluster.

The issue was reproduced with Cilium, but it is not Cilium-specific: the invalid flag is generated for every K3s agent with a Floating IP, regardless of the selected CNI.

## Fix

Remove `flannel-external-ip` from the generated K3s agent configuration while retaining:

```yaml
node-external-ip: <floating-ip>
```

The valid control-plane/server use of `flannel-external-ip` is unchanged. RKE2 agent configuration is also unchanged.

## Upgrade impact

This change does not alter Terraform resource addresses or replace Hetzner infrastructure.

For an existing K3s Floating-IP agent, the generated configuration hash may change, causing the agent configuration provisioner to rewrite the configuration and restart the K3s agent service. Operators should review the plan and roll this out during a maintenance window.

## Regression coverage

The render harness now asserts that:

- K3s agent configuration never contains `flannel-external-ip`.
- Floating-IP agents continue to receive `node-external-ip`.

The regression precondition was confirmed against the unmodified `master` branch, where the K3s agent configuration still contains the invalid flag.

## Verification

- `terraform fmt -check -recursive`
- `python3 scripts/render_harness.py`
- `tofu validate -no-color`
- Confirmed on K3s `v1.34.10+k3s1`:
  - `k3s agent --help`: `flannel-external-ip` absent
  - `k3s server --help`: `flannel-external-ip` present
- Live reproduction confirmed that the server-only flag prevents the K3s agent service from starting.

## AI assistance disclosure

OpenAI Codex assisted with diagnosing the live K3s failure, tracing the regression to the generated agent configuration, preparing the code and regression test, and drafting this pull-request description. The reported runtime behavior and validation results were checked against the repository and the affected canary node.