### PR TITLE
Fix project-aware cluster cleanup

### DIFF
--- a/.claude/skills/debug-node/SKILL.md
+++ b/.claude/skills/debug-node/SKILL.md
@@ -282,4 +282,4 @@ ssh -vvv -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519 root@<SERVER_IP>
 6. **Volatile overlay trap** — if rescue shows different content than the live system did, it was running on a volatile overlay that never got committed
 7. **After fixing packer, rebuild snapshots** — verify build logs show changes inside the `transactional-update` output
 8. **Rescue mode is non-destructive** — you're just reading/writing files on the disk
-9. **Destroy with the wrapper** — for full-cluster teardown, run `scripts/destroy.sh` from the Terraform root; it retries only the known ingress-LB detach race and prints a read-only orphan report. Use `scripts/cleanup.sh` only as the forceful fallback.
+9. **Destroy with the wrapper** — for full-cluster teardown, run `scripts/destroy.sh` from the Terraform root; it retries only the known ingress-LB detach race and prints a read-only orphan report. Use `scripts/cleanup.sh` only as the forceful fallback; it treats the token's entire HCloud project as cluster-dedicated, so review the dry run first.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -189,7 +189,9 @@ For destroy/teardown issues, start with `scripts/destroy.sh`, not manual cloud
 deletes. It runs Terraform/OpenTofu destroy, auto-retries only the known benign
 ingress-LB detach race, and then prints a read-only orphan report. Use
 `scripts/cleanup.sh` only as the forceful fallback when state is already wrecked
-or the read-only report identifies leftovers to delete.
+or the read-only report identifies leftovers to delete. It treats the token's
+entire HCloud project as cluster-dedicated; review the dry run and include
+persistent data only deliberately.
 
 Autoscaler-created servers are outside Terraform state. If they pin the network
 during destroy, delete them only after the control plane/Cluster Autoscaler is

--- a/.claude/skills/kh-assistant/SKILL.md
+++ b/.claude/skills/kh-assistant/SKILL.md
@@ -161,7 +161,7 @@ Verify the live tag at startup; the checked-in release baseline is **v3.1.0**.
 | Enabling embedded registry mirror on low-trust nodes | Use only for equal-trust clusters; warn about credential sharing and tag poisoning |
 | Disabling SELinux globally for one workload denial | Follow `docs/selinux.md`: collect AVCs, try udica, use per-pool `selinux = false` only as the last resort |
 | Assuming RKE2 needs 8GB control planes | v3 size-aware kubelet reservations make 4GB `cx23` control planes viable; still size production for workload headroom |
-| Manual cloud deletes during teardown | Use `scripts/destroy.sh` first; `scripts/cleanup.sh` is the forceful fallback |
+| Manual cloud deletes during teardown | Use `scripts/destroy.sh` first; `scripts/cleanup.sh` is the forceful fallback and targets the token's entire HCloud project |
 
 ### v3 Topology Shortcuts
 
@@ -342,7 +342,9 @@ kubeconfig after certificate recovery.
    control plane is dead. Then use the orphan report to identify and delete only
    the autoscaler-created servers, and rerun `scripts/destroy.sh`.
 4. Use <module-checkout>/scripts/cleanup.sh only when state is already broken or
-   the read-only report identifies leftovers; review its dry run before deletion.
+   the read-only report identifies leftovers. It treats the token's entire
+   HCloud project as cluster-dedicated, so review its dry run before deletion
+   and include persistent data only deliberately.
 ```
 
 ### Workflow: Feature Questions

--- a/.claude/skills/migrate-v2-to-v3/SKILL.md
+++ b/.claude/skills/migrate-v2-to-v3/SKILL.md
@@ -286,7 +286,9 @@ Do not panic-abort a healthy first v3 plan for these expected actions:
   then prints a read-only orphan report for unlabeled primary IPs,
   out-of-state autoscaled nodes, and exact managed LB names. Use
   `scripts/cleanup.sh` only as the forceful fallback after the report shows
-  leftovers or state is already wrecked.
+  leftovers or state is already wrecked. It treats the token's entire HCloud
+  project as cluster-dedicated; review the dry run and include persistent data
+  only deliberately.
 - Autoscaler-created servers are not in Terraform state and can pin
   network/subnet deletion. Delete those orphans only after the control plane is
   dead, or first scale the autoscaler pool to `min_nodes = 0`; deleting them

--- a/.claude/skills/running-stabilization-loop/SKILL.md
+++ b/.claude/skills/running-stabilization-loop/SKILL.md
@@ -148,22 +148,18 @@ If resources are stuck (especially autoscaler nodes), run:
 
 ```bash
 cd /Volumes/MysticalTech/Code/kube-test
-/Volumes/MysticalTech/Code/kube-hetzner/scripts/cleanup.sh
+/Volumes/MysticalTech/Code/kube-hetzner/scripts/cleanup.sh --dry-run
+/Volumes/MysticalTech/Code/kube-hetzner/scripts/cleanup.sh --execute
 ```
+
+The force cleanup treats the Terraform token's entire HCloud project as
+cluster-dedicated. Inspect every dry-run row before the typed confirmation and
+include volumes, snapshots, DNS zones, or Storage Boxes only deliberately.
 
 Optional alias:
 
 ```bash
 alias cleanupkh='/Volumes/MysticalTech/Code/kube-hetzner/scripts/cleanup.sh'
-```
-
-And if autoscaled servers still exist, delete directly:
-
-```bash
-ids="$(hcloud server list -o columns=id,name | awk '/khv3-/{print $1}')"
-if [ -n "$ids" ]; then
-  echo "$ids" | xargs -n1 hcloud server delete
-fi
 ```
 
 ## Step 3: Verify Snapshot Prerequisites

--- a/.claude/skills/test-changes/SKILL.md
+++ b/.claude/skills/test-changes/SKILL.md
@@ -286,7 +286,9 @@ known benign ingress-LB detach race (`resource_already_detaching`/422 from dual
 CCM and Terraform ownership), then prints a read-only orphan report including
 unlabeled primary IPs, out-of-state autoscaled nodes, and exact managed load
 balancer names. Use `scripts/cleanup.sh` only as the forceful fallback after the
-report shows leftovers or state is already wrecked.
+report shows leftovers or state is already wrecked. It treats the token's
+entire HCloud project as cluster-dedicated; review the dry run and include
+persistent data only deliberately.
 
 Autoscaler-created servers are not in Terraform state. If an autoscaled server
 pins the network/subnet during destroy, delete it only after the control plane is

--- a/.claude/skills/upgrade-cluster/SKILL.md
+++ b/.claude/skills/upgrade-cluster/SKILL.md
@@ -344,7 +344,9 @@ If an upgrade exercise is on a disposable cluster and must be torn down, run
 `scripts/destroy.sh` from the Terraform root. It auto-retries only the known
 benign ingress-LB detach race and then prints a read-only orphan report. Use
 `scripts/cleanup.sh` only as the forceful fallback when state is already broken
-or the report identifies leftovers.
+or the report identifies leftovers. It treats the token's entire HCloud project
+as cluster-dedicated; review the dry run and include persistent data only
+deliberately.
 
 Autoscaler-created servers are outside Terraform state. If they pin
 network/subnet deletion, delete them only after the control plane is dead, or

--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -142,6 +142,7 @@ jobs:
           packer init packer-template/hcloud-microos-snapshots.pkr.hcl
           packer validate -var hcloud_token=ci-validation-placeholder packer-template/hcloud-microos-snapshots.pkr.hcl
           shellcheck --severity=warning packer-template/scripts/*.sh scripts/*.sh scripts/tests/*.sh
+          scripts/tests/test_cleanup.sh
           scripts/tests/test_packer_trust_anchors.sh
           scripts/tests/test_leapmicro_verifier.sh
           scripts/tests/test_leapmicro_transactional_cleanup.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### ⚠️ Upgrade Notes
 
+- **Force cleanup scope and timeout:** `cleanupkh` now treats the HCloud project selected by the Terraform token as dedicated to one cluster and proposes deleting every runtime resource in that project, including unrelated resources. It defaults to a dry run; persistent data remains opt-in. Existing v3.1.0 K3s and RKE2 clusters also show an expected in-place update to the ingress load balancer destroy-cleanup `terraform_data` on the next apply. That apply must persist the new 45-second SSH timeout before a later destroy can use it.
 - **Additional firewall ownership:** `extra_firewall_ids` are authoritative through each module-managed server. If the same server/firewall relationship is currently managed by a standalone `hcloud_firewall_attachment`, follow the state-only ownership handoff in [`docs/operations.md`](docs/operations.md#handoff-an-existing-firewall-attachment) before applying; two Terraform resources must not manage the same attachment.
 - **Label-selected SSH keys:** every key matched by `ssh_hcloud_key_label` must be a valid RSA, Ed25519, ECDSA NIST P-256/P-384/P-521, or OpenSSH FIDO public key. Unsupported legacy DSA keys, OpenSSH certificates, and malformed key lines now fail during plan instead of failing node bootstrap.
 - **Existing autoscaler nodes:** new autoscaler nodes restore both `health-checker.service` and the configured `transactional-update.timer` state after bootstrap. Existing autoscaler nodes retain their original cloud-init; use the in-place service repair in [`docs/operations.md`](docs/operations.md#repair-existing-autoscaler-update-services) or recycle them gradually. Static nodes are repaired automatically on the next apply. Restoring `health-checker.service` also restores the next-boot transactional snapshot health validation and automatic rollback semantics that are deliberately suppressed during first-boot Kubernetes provisioning.
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 🔧 Changes
 
+- Rebuilt `cleanupkh` as a fail-closed, project-aware CLI. It ignores ambient HCloud credentials, pins every API call to the Terraform token, verifies and activates the cluster-named context, inventories all runtime resources and snapshots before mutation, filters empty CLI rows, handles delete protection, separates persistent-data choices, and verifies the final inventory. Best-effort ingress cleanup now gives up on unreachable SSH after 45 seconds instead of retrying for ten minutes.
 - Kept GitHub CI focused on cheap required lint, documentation drift, and tag publication; HCloud smoke, credentials, cluster inspection, and teardown now remain local. Tag publication rejects missing release notes.
 - Restored the one-command `createkh` and `cleanupkh` flows for Bash/Zsh and Fish. `scripts/create.sh` again works when downloaded directly, while manifest verification and atomic Packer bundle publication stay behind the simple entrypoint.
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Forceful cleanup fallback:
 ```
 
 > [!WARNING]
-> `cleanup.sh` can delete every matching server, network, load balancer, placement group, SSH key, and volume. Review its dry run before confirming.
+> `cleanup.sh` resolves the Terraform HCloud token, activates the matching cluster-named context, and treats that project as dedicated to the cluster. Its dry run includes unrelated runtime resources in the same project; volumes, snapshots, DNS zones, and Storage Boxes require separate opt-in. If Terraform was applied with `-var="hcloud_token=..."`, export that same value as `TF_VAR_hcloud_token` or pass it through `--var-file` before cleanup. Review the plan before typing the cluster name to confirm. `--yes` skips that typed confirmation and is intended only for controlled automation.
 
 <details>
 <summary><strong>Fish shell version</strong></summary>
@@ -156,7 +156,7 @@ set tmp_script (mktemp); curl -fsSL -o "$tmp_script" https://raw.githubuserconte
 <summary><strong>Save as <code>cleanupkh</code> (Bash/Zsh)</strong></summary>
 
 ```sh
-cleanupkh() { (tmp_script=$(mktemp) && trap 'rm -f "$tmp_script"' EXIT && curl -fsSL -o "$tmp_script" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/scripts/cleanup.sh && chmod +x "$tmp_script" && "$tmp_script"); }
+cleanupkh() { (tmp_script=$(mktemp) && trap 'rm -f "$tmp_script"' EXIT && curl -fsSL -o "$tmp_script" https://raw.githubusercontent.com/kube-hetzner/terraform-hcloud-kube-hetzner/master/scripts/cleanup.sh && chmod +x "$tmp_script" && "$tmp_script" "$@"); }
 ```
 
 </details>

--- a/locals.tf
+++ b/locals.tf
@@ -2624,7 +2624,7 @@ EOT
     ssh_agent_identity  = local.ssh_agent_identity
     ssh_host            = local.first_control_plane_ip
     ssh_port            = var.ssh_port
-    ssh_timeout         = "10m"
+    ssh_timeout         = "45s"
     bastion_host        = local.ssh_bastion.bastion_host
     bastion_port        = local.ssh_bastion.bastion_port
     bastion_user        = local.ssh_bastion.bastion_user

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,297 +1,625 @@
 #!/usr/bin/env bash
 
+set -o pipefail
+
+PROGRAM_NAME="${0##*/}"
 DRY_RUN=1
+MODE_WAS_SET=0
+ASSUME_YES=0
+DELETE_VOLUMES=0
+DELETE_SNAPSHOTS=0
+DELETE_DNS_ZONES=0
+DELETE_STORAGE_BOXES=0
+VOLUME_POLICY_WAS_SET=0
+SNAPSHOT_POLICY_WAS_SET=0
+DNS_ZONE_POLICY_WAS_SET=0
+STORAGE_BOX_POLICY_WAS_SET=0
+CLUSTER_NAME="${CLUSTER_NAME:-}"
+ROOT_HCLOUD_TOKEN=""
+ROOT_HCLOUD_TOKEN_SOURCE=""
+UNPARSED_HCLOUD_TOKEN_SOURCE=""
+SELECTED_HCLOUD_CONTEXT=""
+HCLOUD_API_ENDPOINT="https://api.hetzner.cloud/v1"
+HETZNER_API_ENDPOINT="https://api.hetzner.com/v1"
+DNS_ZONE_INVENTORY_AVAILABLE=0
+STORAGE_BOX_INVENTORY_AVAILABLE=0
+TF_VAR_FILES=()
+HCLOUD_LINES=()
+CLEANUP_FAILURES=0
 
-echo "Welcome to the Kube-Hetzner cluster deletion script!"
-echo " "
-echo "We advise you to first run 'terraform destroy' and execute that script when it starts hanging because of resources still attached to the network."
-echo "In order to run this script need to have the hcloud CLI installed and configured with a context for the cluster you want to delete."
-command -v hcloud >/dev/null 2>&1 || { echo "hcloud (Hetzner CLI) is not installed. Install it with 'brew install hcloud'."; exit 1; }
-echo "You can do so by running 'hcloud context create <cluster_name>' and inputting your HCLOUD_TOKEN."
-echo " "
+usage() {
+  cat <<EOF
+Usage: $PROGRAM_NAME [options]
 
-if command -v tofu >/dev/null 2>&1 ; then
-    terraform_command=tofu
-elif command -v terraform >/dev/null 2>&1 ; then
-    terraform_command=terraform
-else
-    echo "terraform or tofu is not installed. Install it with 'brew install terraform' or 'brew install opentofu'."
-    exit 1
-fi
-: "$terraform_command"
+Forcefully remove Hetzner Cloud resources after terraform destroy stalls.
+The Hetzner project/context is treated as dedicated to one cluster.
 
+Options:
+  --cluster NAME                    Cluster and hcloud context name
+  --var-file PATH                   Terraform tfvars file used for this cluster
+  --dry-run                         Show the deletion plan (default)
+  --execute                         Delete the selected resources
+  --include-volumes                 Delete every volume in the context
+  --include-snapshots               Delete every snapshot in the context
+  --include-dns-zones               Delete every DNS zone in the context
+  --include-storage-boxes           Delete every Storage Box in the context
+  --include-all-persistent          Enable all four persistent-data options
+  --yes                             Skip interactive confirmation
+  -h, --help                        Show this help
 
-# Try to guess the cluster name
-GUESSED_CLUSTER_NAME=$(sed -n 's/^[[:space:]]*cluster_name[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' kube.tf 2>/dev/null)
+Authentication is resolved from Terraform inputs: TF_VAR_hcloud_token,
+terraform.tfvars(.json), *.auto.tfvars(.json), explicit --var-file values, or
+a literal kube.tf assignment. Pass every -var-file used for terraform apply in
+the same order. Terraform -var values cannot be discovered; export the same
+token as TF_VAR_hcloud_token or put it in a --var-file before cleanup. Ambient
+HCloud credentials, endpoints, and debug settings are ignored so they cannot
+retarget or record cleanup traffic. The exact token is stored in and activates
+a context named after the cluster; a mismatched context is preserved under a
+timestamped name.
 
-if [ -n "$GUESSED_CLUSTER_NAME" ]; then
-  echo "Cluster name '$GUESSED_CLUSTER_NAME' has been detected in the kube.tf file."
-  read -r -p "Enter the name of the cluster to delete (default: $GUESSED_CLUSTER_NAME): " CLUSTER_NAME
-  if [ -z "$CLUSTER_NAME" ]; then
-    CLUSTER_NAME="$GUESSED_CLUSTER_NAME"
+Examples:
+  $PROGRAM_NAME --cluster test13 --dry-run
+  $PROGRAM_NAME --cluster test13 --execute --include-volumes
+EOF
+}
+
+die() {
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
+}
+
+warn() {
+  printf 'Warning: %s\n' "$*" >&2
+}
+
+prompt_yes_no() {
+  local prompt="$1"
+  local default_answer="${2:-no}"
+  local answer
+
+  if [ ! -t 0 ]; then
+    [ "$default_answer" = "yes" ]
+    return
   fi
-else
-  read -r -p "Enter the name of the cluster to delete: " CLUSTER_NAME
-fi
 
-while true; do
-  read -r -p "Do you want to perform a dry run? (yes/no): " dry_run_input
-  case $dry_run_input in
-    [Yy]* ) DRY_RUN=1; break;;
-    [Nn]* ) DRY_RUN=0; break;;
-    * ) echo "Please answer yes or no.";;
+  if [ "$default_answer" = "yes" ]; then
+    read -r -p "$prompt [Y/n] " answer
+    case "$answer" in
+      ""|[Yy]|[Yy][Ee][Ss]) return 0 ;;
+      *) return 1 ;;
+    esac
+  else
+    read -r -p "$prompt [y/N] " answer
+    case "$answer" in
+      [Yy]|[Yy][Ee][Ss]) return 0 ;;
+      *) return 1 ;;
+    esac
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --cluster)
+      [ "$#" -ge 2 ] || die "--cluster requires a value."
+      CLUSTER_NAME="$2"
+      shift 2
+      ;;
+    --cluster=*)
+      CLUSTER_NAME="${1#*=}"
+      shift
+      ;;
+    --var-file)
+      [ "$#" -ge 2 ] || die "--var-file requires a path."
+      TF_VAR_FILES+=("$2")
+      shift 2
+      ;;
+    --var-file=*)
+      TF_VAR_FILES+=("${1#*=}")
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      MODE_WAS_SET=1
+      shift
+      ;;
+    --execute)
+      DRY_RUN=0
+      MODE_WAS_SET=1
+      shift
+      ;;
+    --include-volumes)
+      DELETE_VOLUMES=1
+      VOLUME_POLICY_WAS_SET=1
+      shift
+      ;;
+    --include-snapshots)
+      DELETE_SNAPSHOTS=1
+      SNAPSHOT_POLICY_WAS_SET=1
+      shift
+      ;;
+    --include-dns-zones)
+      DELETE_DNS_ZONES=1
+      DNS_ZONE_POLICY_WAS_SET=1
+      shift
+      ;;
+    --include-storage-boxes)
+      DELETE_STORAGE_BOXES=1
+      STORAGE_BOX_POLICY_WAS_SET=1
+      shift
+      ;;
+    --include-all-persistent)
+      DELETE_VOLUMES=1
+      DELETE_SNAPSHOTS=1
+      DELETE_DNS_ZONES=1
+      DELETE_STORAGE_BOXES=1
+      VOLUME_POLICY_WAS_SET=1
+      SNAPSHOT_POLICY_WAS_SET=1
+      DNS_ZONE_POLICY_WAS_SET=1
+      STORAGE_BOX_POLICY_WAS_SET=1
+      shift
+      ;;
+    --yes)
+      ASSUME_YES=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      die "Unknown option: $1. Run '$PROGRAM_NAME --help' for usage."
+      ;;
   esac
 done
 
-read -r -p "Do you want to delete volumes? (yes/no, default: no): " delete_volumes_input
-DELETE_VOLUMES=0
-if [[ "$delete_volumes_input" =~ ^([Yy]es|[Yy])$ ]]; then
-  DELETE_VOLUMES=1
-fi
+[ "$#" -eq 0 ] || die "Unexpected positional argument: $1"
+command -v hcloud >/dev/null 2>&1 || die "hcloud CLI is required. Install it with 'brew install hcloud'."
 
-read -r -p "Do you want to delete MicroOS snapshots? (yes/no, default: no): " delete_microos_snapshots_input
-DELETE_MICROOS_SNAPSHOTS=0
-if [[ "$delete_microos_snapshots_input" =~ ^([Yy]es|[Yy])$ ]]; then
-  DELETE_MICROOS_SNAPSHOTS=1
-fi
-
-read -r -p "Do you want to delete Leap Micro snapshots? (yes/no, default: no): " delete_leapmicro_snapshots_input
-DELETE_LEAPMICRO_SNAPSHOTS=0
-if [[ "$delete_leapmicro_snapshots_input" =~ ^([Yy]es|[Yy])$ ]]; then
-  DELETE_LEAPMICRO_SNAPSHOTS=1
-fi
-
-if (( DRY_RUN == 0 )); then
-  echo "WARNING: STUFF WILL BE DELETED!"
+HCLOUD_VERSION_OUTPUT=$(env -u HCLOUD_TOKEN -u HCLOUD_CONTEXT -u HCLOUD_ENDPOINT -u HETZNER_ENDPOINT \
+  -u HCLOUD_DEBUG -u HCLOUD_DEBUG_FILE -u HCLOUD_QUIET -u HCLOUD_POLL_INTERVAL \
+  hcloud --debug=false --debug-file="" --quiet=false --poll-interval 500ms version 2>/dev/null || true)
+if [[ "$HCLOUD_VERSION_OUTPUT" =~ ^hcloud[[:space:]]+v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+  HCLOUD_VERSION_MAJOR="${BASH_REMATCH[1]}"
+  HCLOUD_VERSION_MINOR="${BASH_REMATCH[2]}"
+  HCLOUD_VERSION_PATCH="${BASH_REMATCH[3]}"
 else
-  echo "Performing a dry run, nothing will be deleted."
+  die "Could not determine the hcloud CLI version. hcloud >= 1.59.0 is required."
+fi
+if [ "$HCLOUD_VERSION_MAJOR" -lt 1 ] || { [ "$HCLOUD_VERSION_MAJOR" -eq 1 ] && [ "$HCLOUD_VERSION_MINOR" -lt 59 ]; }; then
+  die "hcloud >= 1.59.0 is required; found $HCLOUD_VERSION_MAJOR.$HCLOUD_VERSION_MINOR.$HCLOUD_VERSION_PATCH. Update the hcloud CLI before cleanup."
 fi
 
-HCLOUD_SELECTOR=(--selector='provisioner=terraform' --selector="cluster=$CLUSTER_NAME")
-HCLOUD_OUTPUT_OPTIONS=(-o noheader -o 'columns=id')
-HCLOUD_ID_NAME_OUTPUT_OPTIONS=(-o noheader -o 'columns=id,name')
+if [ -z "$CLUSTER_NAME" ]; then
+  GUESSED_CLUSTER_NAME=$(sed -n 's/^[[:space:]]*cluster_name[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' kube.tf 2>/dev/null | head -n 1)
+  if [ -n "$GUESSED_CLUSTER_NAME" ] && [ -t 0 ]; then
+    printf "Detected cluster '%s' in kube.tf.\n" "$GUESSED_CLUSTER_NAME"
+    read -r -p "Cluster name [$GUESSED_CLUSTER_NAME]: " CLUSTER_NAME
+    CLUSTER_NAME="${CLUSTER_NAME:-$GUESSED_CLUSTER_NAME}"
+  elif [ -n "$GUESSED_CLUSTER_NAME" ]; then
+    CLUSTER_NAME="$GUESSED_CLUSTER_NAME"
+  elif [ -t 0 ]; then
+    read -r -p "Cluster name: " CLUSTER_NAME
+  fi
+fi
 
-VOLUMES=()
-while IFS='' read -r line; do VOLUMES+=("$line"); done < <(hcloud volume list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
+[ -n "$CLUSTER_NAME" ] || die "Cluster name is required. Use --cluster NAME or run from a root containing kube.tf."
+if ! [[ "$CLUSTER_NAME" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+  die "Cluster name may contain only letters, numbers, dots, underscores, and hyphens."
+fi
 
-SERVERS=()
-while IFS='' read -r line; do SERVERS+=("$line"); done < <(hcloud server list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
-
-PLACEMENT_GROUPS=()
-while IFS='' read -r line; do PLACEMENT_GROUPS+=("$line"); done < <(hcloud placement-group list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
-
-LOAD_BALANCERS=()
-while IFS='' read -r line; do LOAD_BALANCERS+=("$line"); done < <(
-  {
-    hcloud load-balancer list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}"
-    hcloud load-balancer list "${HCLOUD_ID_NAME_OUTPUT_OPTIONS[@]}" | awk -v cluster="$CLUSTER_NAME" '
-      $2 == cluster ||
-      $2 == cluster "-traefik" ||
-      $2 == cluster "-nginx" ||
-      $2 == cluster "-haproxy" { print $1 }
-    '
-  } | awk 'NF && !seen[$1]++ { print $1 }'
-)
-
-FLOATING_IPS=()
-while IFS='' read -r line; do FLOATING_IPS+=("$line"); done < <(hcloud floating-ip list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
-
-PRIMARY_IPS=()
-while IFS='' read -r line; do PRIMARY_IPS+=("$line"); done < <(
-  hcloud primary-ip list "${HCLOUD_ID_NAME_OUTPUT_OPTIONS[@]}" | awk -v cluster="$CLUSTER_NAME" '
-    function has_prefix_suffix(value, prefix, suffix) {
-      return index(value, prefix) == 1 &&
-        length(value) > length(prefix) + length(suffix) &&
-        substr(value, length(value) - length(suffix) + 1) == suffix
-    }
-    {
-      name = $2
-      matched = 0
-      if (has_prefix_suffix(name, cluster "-agent-", "-ipv4")) matched = 1
-      if (has_prefix_suffix(name, cluster "-agent-", "-ipv6")) matched = 1
-      if (has_prefix_suffix(name, cluster "-cp-", "-ipv4")) matched = 1
-      if (has_prefix_suffix(name, cluster "-cp-", "-ipv6")) matched = 1
-      if (name == cluster "-nat-router-ipv4") matched = 1
-      if (name == cluster "-nat-router-ipv6") matched = 1
-      if (has_prefix_suffix(name, cluster "-nat-router-", "-ipv4")) matched = 1
-      if (has_prefix_suffix(name, cluster "-nat-router-", "-ipv6")) matched = 1
-      if (matched) {
-        print $1
-      }
-    }
-  '
-)
-
-FIREWALLS=()
-while IFS='' read -r line; do FIREWALLS+=("$line"); done < <(hcloud firewall list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
-
-NETWORKS=()
-while IFS='' read -r line; do NETWORKS+=("$line"); done < <(hcloud network list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
-
-SSH_KEYS=()
-while IFS='' read -r line; do SSH_KEYS+=("$line"); done < <(hcloud ssh-key list "${HCLOUD_SELECTOR[@]}" "${HCLOUD_OUTPUT_OPTIONS[@]}")
-
-function detach_volumes() {
-  for ID in "${VOLUMES[@]}"; do
-    echo "Detach volume: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud volume detach "$ID"
-    fi
-  done
+extract_literal_token() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  sed -nE 's@^[[:space:]]*hcloud_token[[:space:]]*=[[:space:]]*"([A-Za-z0-9._-]{20,})"[[:space:]]*((#|//).*)?$@\1@p' "$file" | tail -n 1
 }
 
-function delete_volumes() {
-  for ID in "${VOLUMES[@]}"; do
-    echo "Delete volume: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud volume delete "$ID"
-    fi
-  done
+extract_json_literal_token() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  sed -nE 's/.*"hcloud_token"[[:space:]]*:[[:space:]]*"([A-Za-z0-9._-]{20,})".*/\1/p' "$file" | tail -n 1
 }
 
-function delete_servers() {
-  for ID in "${SERVERS[@]}"; do
-    echo "Delete server: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud server delete "$ID"
-    fi
-  done
+extract_token_from_var_file() {
+  case "$1" in
+    *.json) extract_json_literal_token "$1" ;;
+    *) extract_literal_token "$1" ;;
+  esac
 }
 
-function delete_placement_groups() {
-  for ID in "${PLACEMENT_GROUPS[@]}"; do
-    echo "Delete placement-group: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud placement-group delete "$ID"
-    fi
-  done
+token_assignment_present() {
+  case "$1" in
+    *.json) grep -Eq '"hcloud_token"[[:space:]]*:' "$1" ;;
+    *) grep -Eq '^[[:space:]]*hcloud_token[[:space:]]*=' "$1" ;;
+  esac
 }
 
-function delete_load_balancer() {
-  for ID in "${LOAD_BALANCERS[@]}"; do
-    echo "Delete load-balancer: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud load-balancer delete "$ID"
-    fi
-  done
+consider_var_file() {
+  local file="$1"
+  local source_label="$2"
+  local candidate
+
+  [ -f "$file" ] || return 0
+  candidate=$(extract_token_from_var_file "$file")
+  if [ -n "$candidate" ]; then
+    ROOT_HCLOUD_TOKEN="$candidate"
+    ROOT_HCLOUD_TOKEN_SOURCE="$source_label"
+    UNPARSED_HCLOUD_TOKEN_SOURCE=""
+  elif token_assignment_present "$file"; then
+    ROOT_HCLOUD_TOKEN=""
+    ROOT_HCLOUD_TOKEN_SOURCE=""
+    UNPARSED_HCLOUD_TOKEN_SOURCE="$source_label"
+  fi
 }
 
-function delete_floating_ips() {
-  for ID in "${FLOATING_IPS[@]}"; do
-    echo "Delete floating-ip: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud floating-ip delete "$ID"
-    fi
+resolve_root_hcloud_token() {
+  local file
+  local candidate
+
+  if [ -n "${TF_VAR_hcloud_token:-}" ]; then
+    ROOT_HCLOUD_TOKEN="$TF_VAR_hcloud_token"
+    ROOT_HCLOUD_TOKEN_SOURCE="TF_VAR_hcloud_token"
+  fi
+
+  for file in terraform.tfvars terraform.tfvars.json; do
+    consider_var_file "$file" "$file"
   done
+
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    consider_var_file "$file" "${file#./}"
+  done < <(find . -maxdepth 1 \( -name '*.auto.tfvars' -o -name '*.auto.tfvars.json' \) -print | LC_ALL=C sort)
+
+  for file in "${TF_VAR_FILES[@]}"; do
+    [ -f "$file" ] || die "Terraform variable file not found: $file"
+    consider_var_file "$file" "$file (--var-file)"
+  done
+
+  [ -z "$UNPARSED_HCLOUD_TOKEN_SOURCE" ] \
+    || die "The highest-precedence hcloud_token assignment in $UNPARSED_HCLOUD_TOKEN_SOURCE is not a literal string. Refusing to fall back to a different project token."
+
+  if [ -z "$ROOT_HCLOUD_TOKEN" ]; then
+    candidate=$(extract_literal_token kube.tf)
+    if [ -n "$candidate" ]; then
+      ROOT_HCLOUD_TOKEN="$candidate"
+      ROOT_HCLOUD_TOKEN_SOURCE="kube.tf"
+    fi
+  fi
 }
 
-function delete_primary_ips() {
-  for ID in "${PRIMARY_IPS[@]}"; do
-    echo "Delete primary-ip: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud primary-ip delete "$ID"
-    fi
-  done
+hcloud_context_cli() {
+  env -u HCLOUD_TOKEN -u HCLOUD_CONTEXT -u HCLOUD_ENDPOINT -u HETZNER_ENDPOINT \
+    -u HCLOUD_DEBUG -u HCLOUD_DEBUG_FILE -u HCLOUD_QUIET -u HCLOUD_POLL_INTERVAL \
+    hcloud --debug=false --debug-file="" --quiet=false --poll-interval 500ms "$@"
 }
 
-function delete_firewalls() {
-  for ID in "${FIREWALLS[@]}"; do
-    echo "Delete firewall: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud firewall delete "$ID"
-    fi
-  done
+context_exists() {
+  hcloud_context_cli context list -o noheader -o 'columns=name' 2>/dev/null \
+    | sed 's/[[:space:]]*$//' \
+    | grep -Fx "$1" >/dev/null
 }
 
-function delete_networks() {
-  for ID in "${NETWORKS[@]}"; do
-    echo "Delete network: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud network delete "$ID"
-    fi
-  done
+context_token() {
+  local wanted_context="$1"
+  hcloud_context_cli --context "$wanted_context" config get token --allow-sensitive 2>/dev/null
 }
 
-function delete_ssh_keys() {
-  for ID in "${SSH_KEYS[@]}"; do
-    echo "Delete ssh-key: $ID"
-    if (( DRY_RUN == 0 )); then
-      hcloud ssh-key delete "$ID"
-    fi
-  done
-}
+create_cluster_context() {
+  local existing_token=""
+  local preserved_context
 
-function delete_autoscaled_nodes() {
-  local servers=()
-  while IFS='' read -r line; do servers+=("$line"); done < <(
-    hcloud server list "${HCLOUD_ID_NAME_OUTPUT_OPTIONS[@]}" | awk -v prefix="$CLUSTER_NAME-" '
-      index($2, prefix) == 1 { print $1 " " $2 }
-    '
-  )
+  [ -n "$ROOT_HCLOUD_TOKEN" ] || die "No authoritative hcloud token was resolved for cluster '$CLUSTER_NAME'."
 
-  for server_info in "${servers[@]}"; do
-    local ID
-    local server_name
-    local existing_id
-    local already_selected=0
-    ID=$(echo "$server_info" | awk '{print $1}')
-    server_name=$(echo "$server_info" | awk '{print $2}')
-    for existing_id in "${SERVERS[@]}"; do
-      if [ "$existing_id" = "$ID" ]; then
-        already_selected=1
-        break
+  if context_exists "$CLUSTER_NAME"; then
+    existing_token=$(context_token "$CLUSTER_NAME" || true)
+    if [ "$existing_token" != "$ROOT_HCLOUD_TOKEN" ]; then
+      warn "Context '$CLUSTER_NAME' exists with a different token than $ROOT_HCLOUD_TOKEN_SOURCE."
+      if [ "$ASSUME_YES" -ne 1 ] && ! prompt_yes_no "Preserve it under a timestamped name and replace it?" "no"; then
+        die "Refusing to use a context whose token does not match the Terraform root."
       fi
-    done
-    if [ "$already_selected" -eq 1 ]; then
-      continue
+      preserved_context="${CLUSTER_NAME}-previous-$(date +%Y%m%d%H%M%S)-$$"
+      hcloud_context_cli context rename "$CLUSTER_NAME" "$preserved_context" >/dev/null \
+        || die "Could not preserve the existing context as '$preserved_context'."
+      printf "Preserved the previous context as '%s'.\n" "$preserved_context"
+    else
+      return
     fi
-    echo "Delete autoscaled server: $ID (Name: $server_name)"
-    if (( DRY_RUN == 0 )); then
-      hcloud server delete "$ID"
-    fi
+  fi
+
+  env -u HCLOUD_CONTEXT -u HCLOUD_ENDPOINT -u HETZNER_ENDPOINT -u HCLOUD_DEBUG -u HCLOUD_DEBUG_FILE \
+    -u HCLOUD_QUIET -u HCLOUD_POLL_INTERVAL HCLOUD_TOKEN="$ROOT_HCLOUD_TOKEN" \
+    hcloud --debug=false --debug-file="" --quiet=false --poll-interval 500ms \
+    context create "$CLUSTER_NAME" --token-from-env >/dev/null \
+    || die "Could not create hcloud context '$CLUSTER_NAME' from $ROOT_HCLOUD_TOKEN_SOURCE."
+  printf "Created hcloud context '%s' from %s.\n" "$CLUSTER_NAME" "$ROOT_HCLOUD_TOKEN_SOURCE"
+}
+
+resolve_root_hcloud_token
+if [ -n "$ROOT_HCLOUD_TOKEN" ]; then
+  create_cluster_context
+elif context_exists "$CLUSTER_NAME"; then
+  ROOT_HCLOUD_TOKEN=$(context_token "$CLUSTER_NAME" || true)
+  [ -n "$ROOT_HCLOUD_TOKEN" ] || die "Could not read the token from hcloud context '$CLUSTER_NAME'."
+  ROOT_HCLOUD_TOKEN_SOURCE="hcloud context '$CLUSTER_NAME' (no Terraform token found)"
+else
+  die "Context '$CLUSTER_NAME' does not exist and no Terraform hcloud token was found. Set TF_VAR_hcloud_token or a literal hcloud_token in terraform.tfvars."
+fi
+
+hcloud_context_cli context use "$CLUSTER_NAME" >/dev/null || die "Could not activate hcloud context '$CLUSTER_NAME'."
+SELECTED_HCLOUD_CONTEXT=$(hcloud_context_cli context active 2>/dev/null || true)
+[ "$SELECTED_HCLOUD_CONTEXT" = "$CLUSTER_NAME" ] || die "hcloud activated '$SELECTED_HCLOUD_CONTEXT' instead of '$CLUSTER_NAME'."
+
+hcloud_cli() {
+  env -u HCLOUD_CONTEXT -u HCLOUD_ENDPOINT -u HETZNER_ENDPOINT -u HCLOUD_DEBUG -u HCLOUD_DEBUG_FILE \
+    -u HCLOUD_QUIET -u HCLOUD_POLL_INTERVAL HCLOUD_TOKEN="$ROOT_HCLOUD_TOKEN" \
+    hcloud --no-experimental-warnings --debug=false --debug-file="" --quiet=false --poll-interval 500ms \
+    --endpoint "$HCLOUD_API_ENDPOINT" --hetzner-endpoint "$HETZNER_API_ENDPOINT" \
+    --context "$SELECTED_HCLOUD_CONTEXT" "$@"
+}
+
+collect_hcloud_lines() {
+  local description="$1"
+  shift
+  local output
+  local line
+
+  if ! output=$(hcloud_cli "$@"); then
+    printf 'Error: failed to list %s in context %s. No deletion was attempted.\n' "$description" "$SELECTED_HCLOUD_CONTEXT" >&2
+    return 1
+  fi
+
+  HCLOUD_LINES=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] && HCLOUD_LINES+=("$line")
+  done <<< "$output"
+  return 0
+}
+
+collect_hcloud_lines "servers" server list -o noheader -o 'columns=id,name' || exit 1
+SERVERS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "load balancers" load-balancer list -o noheader -o 'columns=id,name' || exit 1
+LOAD_BALANCERS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "networks" network list -o noheader -o 'columns=id,name' || exit 1
+NETWORKS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "firewalls" firewall list -o noheader -o 'columns=id,name' || exit 1
+FIREWALLS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "SSH keys" ssh-key list -o noheader -o 'columns=id,name' || exit 1
+SSH_KEYS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "placement groups" placement-group list -o noheader -o 'columns=id,name' || exit 1
+PLACEMENT_GROUPS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "floating IPs" floating-ip list -o noheader -o 'columns=id,name' || exit 1
+FLOATING_IPS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "primary IPs" primary-ip list -o noheader -o 'columns=id,name' || exit 1
+PRIMARY_IPS=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "certificates" certificate list -o noheader -o 'columns=id,name,type' || exit 1
+CERTIFICATES=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "volumes" volume list -o noheader -o 'columns=id,name,server' || exit 1
+VOLUMES=("${HCLOUD_LINES[@]}")
+collect_hcloud_lines "snapshots" image list --type snapshot -o noheader -o 'columns=id,description,labels' || exit 1
+SNAPSHOTS=("${HCLOUD_LINES[@]}")
+DNS_ZONES=()
+if hcloud_cli zone list --help >/dev/null 2>&1; then
+  if collect_hcloud_lines "DNS zones" zone list -o noheader -o 'columns=id,name'; then
+    DNS_ZONES=("${HCLOUD_LINES[@]}")
+    DNS_ZONE_INVENTORY_AVAILABLE=1
+  else
+    warn "DNS zones could not be inventoried; they will remain untouched."
+  fi
+else
+  warn "This hcloud version cannot inventory DNS zones; they will remain untouched."
+fi
+STORAGE_BOXES=()
+if hcloud_cli storage-box list --help >/dev/null 2>&1; then
+  if collect_hcloud_lines "Storage Boxes" storage-box list -o noheader -o 'columns=id,name'; then
+    STORAGE_BOXES=("${HCLOUD_LINES[@]}")
+    STORAGE_BOX_INVENTORY_AVAILABLE=1
+  else
+    warn "Storage Boxes could not be inventoried; they will remain untouched."
+  fi
+else
+  warn "This hcloud version cannot inventory Storage Boxes; they will remain untouched."
+fi
+
+if [ "$DELETE_DNS_ZONES" -eq 1 ] && [ "$DNS_ZONE_INVENTORY_AVAILABLE" -ne 1 ]; then
+  die "DNS zone deletion was requested, but DNS zones could not be inventoried. No deletion was attempted."
+fi
+if [ "$DELETE_STORAGE_BOXES" -eq 1 ] && [ "$STORAGE_BOX_INVENTORY_AVAILABLE" -ne 1 ]; then
+  die "Storage Box deletion was requested, but Storage Boxes could not be inventoried. No deletion was attempted."
+fi
+
+print_group() {
+  local label="$1"
+  shift
+  [ "$#" -gt 0 ] || return
+  printf '\n%s (%d)\n' "$label" "$#"
+  local entry
+  for entry in "$@"; do
+    printf '  %s\n' "$entry"
   done
 }
 
-function delete_snapshots_by_selector() {
-  local selector="$1"
-  local snapshots=()
-  while IFS='' read -r line; do snapshots+=("$line"); done < <(hcloud image list --selector "$selector" -o noheader -o 'columns=id,name')
+printf '\nKube-Hetzner force cleanup\n'
+printf '%s\n' '============================'
+printf 'Cluster:  %s\n' "$CLUSTER_NAME"
+printf 'Context:  %s (active)\n' "$SELECTED_HCLOUD_CONTEXT"
+printf 'Token:    %s\n' "$ROOT_HCLOUD_TOKEN_SOURCE"
+printf 'Scope:    entire Hetzner project represented by this context\n'
 
-  for snapshot_info in "${snapshots[@]}"; do
-    local ID
-    local snapshot_name
-    ID=$(echo "$snapshot_info" | awk '{print $1}')
-    snapshot_name=$(echo "$snapshot_info" | awk '{print $2}')
-    echo "Delete snapshot: $ID (Name: $snapshot_name)"
-    if (( DRY_RUN == 0 )); then
-      hcloud image delete "$ID"
+print_group "Servers" "${SERVERS[@]}"
+print_group "Load balancers" "${LOAD_BALANCERS[@]}"
+print_group "Networks" "${NETWORKS[@]}"
+print_group "Firewalls" "${FIREWALLS[@]}"
+print_group "SSH keys" "${SSH_KEYS[@]}"
+print_group "Placement groups" "${PLACEMENT_GROUPS[@]}"
+print_group "Floating IPs" "${FLOATING_IPS[@]}"
+print_group "Primary IPs" "${PRIMARY_IPS[@]}"
+print_group "Certificates" "${CERTIFICATES[@]}"
+print_group "Volumes" "${VOLUMES[@]}"
+print_group "Snapshots" "${SNAPSHOTS[@]}"
+print_group "DNS zones" "${DNS_ZONES[@]}"
+print_group "Storage Boxes" "${STORAGE_BOXES[@]}"
+
+printf '\nWarning\n'
+printf '%s\n' '-------'
+printf 'This context is treated as dedicated to cluster %s.\n' "$CLUSTER_NAME"
+printf 'Every listed runtime resource will be deleted, including unrelated or unlabeled resources.\n'
+printf 'Volumes, snapshots, DNS zones, and Storage Boxes are persistent data and require explicit inclusion.\n'
+printf 'The --yes option skips the final typed confirmation; use it only in controlled automation.\n'
+
+if [ "$MODE_WAS_SET" -eq 0 ] && [ "$ASSUME_YES" -ne 1 ] && [ -t 0 ]; then
+  if prompt_yes_no "Execute deletion now? Select no for a dry run." "no"; then
+    DRY_RUN=0
+  fi
+fi
+
+if [ "$DRY_RUN" -eq 0 ] && [ "$ASSUME_YES" -ne 1 ] && [ -t 0 ]; then
+  if [ "$VOLUME_POLICY_WAS_SET" -eq 0 ] && [ "${#VOLUMES[@]}" -gt 0 ] && prompt_yes_no "Delete all volumes?" "no"; then
+    DELETE_VOLUMES=1
+  fi
+  if [ "$SNAPSHOT_POLICY_WAS_SET" -eq 0 ] && [ "${#SNAPSHOTS[@]}" -gt 0 ] && prompt_yes_no "Delete all snapshots?" "no"; then
+    DELETE_SNAPSHOTS=1
+  fi
+  if [ "$DNS_ZONE_POLICY_WAS_SET" -eq 0 ] && [ "${#DNS_ZONES[@]}" -gt 0 ] && prompt_yes_no "Delete all DNS zones?" "no"; then
+    DELETE_DNS_ZONES=1
+  fi
+  if [ "$STORAGE_BOX_POLICY_WAS_SET" -eq 0 ] && [ "${#STORAGE_BOXES[@]}" -gt 0 ] && prompt_yes_no "Delete all Storage Boxes?" "no"; then
+    DELETE_STORAGE_BOXES=1
+  fi
+fi
+
+printf '\nDeletion plan\n'
+printf '%s\n' '-------------'
+printf 'Mode:                 %s\n' "$([ "$DRY_RUN" -eq 1 ] && printf 'DRY RUN' || printf 'EXECUTE')"
+printf 'Runtime resources:    DELETE ALL LISTED\n'
+printf 'Volumes:              %s\n' "$([ "$DELETE_VOLUMES" -eq 1 ] && printf 'DELETE' || printf 'KEEP')"
+printf 'Snapshots:            %s\n' "$([ "$DELETE_SNAPSHOTS" -eq 1 ] && printf 'DELETE' || printf 'KEEP')"
+printf 'DNS zones:            %s\n' "$([ "$DELETE_DNS_ZONES" -eq 1 ] && printf 'DELETE' || printf 'KEEP')"
+printf 'Storage Boxes:        %s\n' "$([ "$DELETE_STORAGE_BOXES" -eq 1 ] && printf 'DELETE' || printf 'KEEP')"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  printf '\nDry run complete. Nothing was deleted. Re-run with --execute when the plan is correct.\n'
+  exit 0
+fi
+
+if [ "$ASSUME_YES" -ne 1 ]; then
+  [ -t 0 ] || die "--execute in a non-interactive shell requires --yes."
+  printf '\nType the cluster name to confirm deletion from context %s: ' "$SELECTED_HCLOUD_CONTEXT"
+  read -r confirmation
+  [ "$confirmation" = "$CLUSTER_NAME" ] || die "Confirmation did not match '$CLUSTER_NAME'. Nothing was deleted."
+fi
+
+resource_id() {
+  printf '%s\n' "$1" | awk '{ print $1 }'
+}
+
+run_hcloud_mutation() {
+  local description="$1"
+  shift
+  local output
+
+  if output=$(hcloud_cli "$@" 2>&1); then
+    [ -n "$output" ] && printf '  %s\n' "$output"
+    return 0
+  fi
+  if printf '%s\n' "$output" | grep -Ei 'not found|already (disabled|deleted)' >/dev/null; then
+    printf '  Already gone: %s\n' "$description"
+    return 0
+  fi
+  printf '  Failed: %s\n  %s\n' "$description" "$output" >&2
+  CLEANUP_FAILURES=$((CLEANUP_FAILURES + 1))
+  return 1
+}
+
+delete_entries() {
+  local label="$1"
+  local resource="$2"
+  local protection="$3"
+  shift 3
+  local entry
+  local id
+
+  for entry in "$@"; do
+    id=$(resource_id "$entry")
+    [ -n "$id" ] || continue
+    printf 'Delete %s %s\n' "$label" "$id"
+    if [ "$protection" = "yes" ]; then
+      run_hcloud_mutation "$label $id protection" "$resource" disable-protection "$id" delete || true
     fi
+    run_hcloud_mutation "$label $id" "$resource" delete "$id" || true
   done
 }
 
-if (( DRY_RUN > 0 )); then
-  echo "Dry run, nothing will be deleted!"
+printf '\nDeleting resources\n'
+printf '%s\n' '------------------'
+delete_entries "server" server yes "${SERVERS[@]}"
+delete_entries "load balancer" load-balancer yes "${LOAD_BALANCERS[@]}"
+if [ "$DELETE_VOLUMES" -eq 1 ]; then
+  delete_entries "volume" volume yes "${VOLUMES[@]}"
+fi
+delete_entries "primary IP" primary-ip yes "${PRIMARY_IPS[@]}"
+delete_entries "floating IP" floating-ip yes "${FLOATING_IPS[@]}"
+delete_entries "placement group" placement-group no "${PLACEMENT_GROUPS[@]}"
+delete_entries "network" network yes "${NETWORKS[@]}"
+delete_entries "firewall" firewall no "${FIREWALLS[@]}"
+delete_entries "certificate" certificate no "${CERTIFICATES[@]}"
+delete_entries "SSH key" ssh-key no "${SSH_KEYS[@]}"
+
+if [ "$DELETE_SNAPSHOTS" -eq 1 ]; then
+  delete_entries "snapshot" image yes "${SNAPSHOTS[@]}"
+fi
+if [ "$DELETE_DNS_ZONES" -eq 1 ]; then
+  delete_entries "DNS zone" zone yes "${DNS_ZONES[@]}"
+fi
+if [ "$DELETE_STORAGE_BOXES" -eq 1 ]; then
+  delete_entries "Storage Box" storage-box yes "${STORAGE_BOXES[@]}"
 fi
 
-detach_volumes
-if (( DELETE_VOLUMES == 1 )); then
-  delete_volumes
-fi
-delete_servers
-delete_autoscaled_nodes
-delete_primary_ips
-delete_floating_ips
-delete_placement_groups
-delete_load_balancer
-delete_networks
-delete_firewalls
-delete_ssh_keys
+VERIFY_FAILURES=0
+verify_absent() {
+  local description="$1"
+  shift
+  collect_hcloud_lines "$description" "$@" || {
+    VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+    return
+  }
+  if [ "${#HCLOUD_LINES[@]}" -gt 0 ]; then
+    printf 'Remaining %s:\n' "$description" >&2
+    printf '  %s\n' "${HCLOUD_LINES[@]}" >&2
+    VERIFY_FAILURES=$((VERIFY_FAILURES + 1))
+  fi
+}
 
-
-if (( DELETE_MICROOS_SNAPSHOTS == 1 )); then
-  delete_snapshots_by_selector "microos-snapshot=yes"
+printf '\nVerifying cleanup\n'
+printf '%s\n' '-----------------'
+verify_absent "servers" server list -o noheader -o 'columns=id,name'
+verify_absent "load balancers" load-balancer list -o noheader -o 'columns=id,name'
+verify_absent "networks" network list -o noheader -o 'columns=id,name'
+verify_absent "firewalls" firewall list -o noheader -o 'columns=id,name'
+verify_absent "SSH keys" ssh-key list -o noheader -o 'columns=id,name'
+verify_absent "placement groups" placement-group list -o noheader -o 'columns=id,name'
+verify_absent "floating IPs" floating-ip list -o noheader -o 'columns=id,name'
+verify_absent "primary IPs" primary-ip list -o noheader -o 'columns=id,name'
+verify_absent "certificates" certificate list -o noheader -o 'columns=id,name,type'
+if [ "$DELETE_VOLUMES" -eq 1 ]; then
+  verify_absent "volumes" volume list -o noheader -o 'columns=id,name,server'
+fi
+if [ "$DELETE_SNAPSHOTS" -eq 1 ]; then
+  verify_absent "snapshots" image list --type snapshot -o noheader -o 'columns=id,description,labels'
+fi
+if [ "$DELETE_DNS_ZONES" -eq 1 ]; then
+  verify_absent "DNS zones" zone list -o noheader -o 'columns=id,name'
+fi
+if [ "$DELETE_STORAGE_BOXES" -eq 1 ]; then
+  verify_absent "Storage Boxes" storage-box list -o noheader -o 'columns=id,name'
 fi
 
-if (( DELETE_LEAPMICRO_SNAPSHOTS == 1 )); then
-  delete_snapshots_by_selector "leapmicro-snapshot=yes"
+[ "$VERIFY_FAILURES" -eq 0 ] || die "$VERIFY_FAILURES resource class(es) still contain selected resources after cleanup."
+if [ "$CLEANUP_FAILURES" -gt 0 ]; then
+  warn "$CLEANUP_FAILURES operation(s) reported errors, but the final inventory confirms that no selected resources remain."
 fi
+printf 'No selected resources remain.\n'
+printf '\nCleanup completed in context %s.\n' "$SELECTED_HCLOUD_CONTEXT"
+printf 'Re-run terraform destroy so Terraform can remove stale state entries, then use a dry run to review any intentionally preserved persistent data.\n'

--- a/scripts/tests/test_cleanup.sh
+++ b/scripts/tests/test_cleanup.sh
@@ -1,0 +1,487 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+cleanup_script="$repo_root/scripts/cleanup.sh"
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+
+fake_bin="$tmp/bin"
+fake_home="$tmp/home"
+fake_state="$tmp/state"
+root="$tmp/root"
+fake_config="$tmp/nonstandard-config/cli.toml"
+mkdir -p "$fake_bin" "$fake_home" "${fake_config%/*}" "$fake_state/contexts" "$root"
+
+grep -Eq 'ssh_timeout[[:space:]]*=[[:space:]]*"45s"' "$repo_root/locals.tf" \
+  || { echo 'destroy-time ingress cleanup must not retry unreachable SSH for ten minutes' >&2; exit 1; }
+
+cat > "$fake_bin/hcloud" <<'FAKE_HCLOUD'
+#!/usr/bin/env bash
+set -euo pipefail
+
+state=${FAKE_HCLOUD_STATE:?}
+log=${FAKE_HCLOUD_LOG:?}
+config=${HCLOUD_CONFIG:?}
+[ -z "${HCLOUD_ENDPOINT:-}" ] || { printf 'ambient cloud endpoint reached hcloud\n' >&2; exit 20; }
+[ -z "${HETZNER_ENDPOINT:-}" ] || { printf 'ambient Hetzner endpoint reached hcloud\n' >&2; exit 21; }
+[ -z "${HCLOUD_DEBUG:-}" ] || { printf 'ambient debug setting reached hcloud\n' >&2; exit 22; }
+[ -z "${HCLOUD_DEBUG_FILE:-}" ] || { printf 'ambient debug file reached hcloud\n' >&2; exit 23; }
+[ -z "${HCLOUD_QUIET:-}" ] || { printf 'ambient quiet setting reached hcloud\n' >&2; exit 24; }
+[ -z "${HCLOUD_POLL_INTERVAL:-}" ] || { printf 'ambient poll interval reached hcloud\n' >&2; exit 25; }
+
+render_config() {
+  local name
+  {
+    printf 'active_context = "%s"\n' "$(cat "$state/active")"
+    for token_file in "$state"/contexts/*; do
+      [ -f "$token_file" ] || continue
+      name=${token_file##*/}
+      printf '\n[[contexts]]\n  name = "%s"\n  token = "%s"\n' "$name" "$(cat "$token_file")"
+    done
+  } > "$config"
+}
+
+context=""
+endpoint=""
+hetzner_endpoint=""
+debug=""
+debug_file="not-set"
+quiet=""
+poll_interval=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-experimental-warnings)
+      shift
+      ;;
+    --context)
+      context="$2"
+      shift 2
+      ;;
+    --endpoint)
+      endpoint="$2"
+      shift 2
+      ;;
+    --hetzner-endpoint)
+      hetzner_endpoint="$2"
+      shift 2
+      ;;
+    --debug=*)
+      debug="${1#*=}"
+      shift
+      ;;
+    --debug-file=*)
+      debug_file="${1#*=}"
+      shift
+      ;;
+    --quiet=*)
+      quiet="${1#*=}"
+      shift
+      ;;
+    --poll-interval)
+      poll_interval="$2"
+      shift 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+[ "$debug" = "false" ] || { printf 'debug was not disabled by flag\n' >&2; exit 24; }
+[ -z "$debug_file" ] || { printf 'debug file was not disabled by flag\n' >&2; exit 25; }
+[ "$quiet" = "false" ] || { printf 'quiet was not disabled by flag\n' >&2; exit 26; }
+[ "$poll_interval" = "500ms" ] || { printf 'poll interval was not pinned\n' >&2; exit 27; }
+
+resource=${1:-}
+action=${2:-}
+
+if [ "$resource" = "version" ]; then
+  printf 'hcloud v%s\n' "${FAKE_HCLOUD_VERSION:-1.59.0}"
+  exit 0
+fi
+
+if [ "$resource" = "context" ]; then
+  if [ "$action" = "create" ]; then
+    [ "${HCLOUD_TOKEN:-}" = "${FAKE_EXPECTED_HCLOUD_TOKEN:?}" ] || {
+      printf 'context create received the wrong token\n' >&2
+      exit 30
+    }
+  else
+    [ -z "${HCLOUD_TOKEN:-}" ] || { printf 'ambient token reached context command\n' >&2; exit 30; }
+  fi
+  case "$action" in
+    list)
+      for token_file in "$state"/contexts/*; do
+        [ -f "$token_file" ] || continue
+        name=${token_file##*/}
+        printf '%-20s\n' "$name"
+      done
+      ;;
+    active)
+      cat "$state/active"
+      ;;
+    create)
+      name=$3
+      [ -n "${HCLOUD_TOKEN:-}" ] || exit 31
+      printf '%s' "$HCLOUD_TOKEN" > "$state/contexts/$name"
+      render_config
+      printf 'context create %s\n' "$name" >> "$log"
+      ;;
+    rename)
+      old_name=$3
+      new_name=$4
+      mv "$state/contexts/$old_name" "$state/contexts/$new_name"
+      if [ "$(cat "$state/active")" = "$old_name" ]; then
+        printf '%s' "$new_name" > "$state/active"
+      fi
+      render_config
+      printf 'context rename %s %s\n' "$old_name" "$new_name" >> "$log"
+      ;;
+    use)
+      name=$3
+      [ -f "$state/contexts/$name" ] || exit 32
+      printf '%s' "$name" > "$state/active"
+      render_config
+      printf 'context use %s\n' "$name" >> "$log"
+      ;;
+    *) exit 33 ;;
+  esac
+  exit 0
+fi
+
+[ "$resource" != "config" ] || {
+  [ "$action" = "get" ] && [ "${3:-}" = "token" ] || exit 33
+  [ -z "${HCLOUD_TOKEN:-}" ] || { printf 'ambient token reached config command\n' >&2; exit 34; }
+  [ -n "$context" ] && [ -f "$state/contexts/$context" ] || exit 35
+  cat "$state/contexts/$context"
+  exit 0
+}
+
+[ "$context" = "demo" ] || exit 34
+[ "$endpoint" = "https://api.hetzner.cloud/v1" ] || { printf 'cloud endpoint was not pinned\n' >&2; exit 35; }
+[ "$hetzner_endpoint" = "https://api.hetzner.com/v1" ] || { printf 'Hetzner endpoint was not pinned\n' >&2; exit 36; }
+[ "${HCLOUD_TOKEN:-}" = "${FAKE_EXPECTED_HCLOUD_TOKEN:?}" ] || {
+  printf 'API command received the wrong token\n' >&2
+  exit 36
+}
+for argument in "$@"; do
+  [ "$argument" != "--help" ] || exit 0
+done
+if [ "$action" = "list" ]; then
+  if [ "${FAKE_HCLOUD_FAIL_RESOURCE:-}" = "$resource" ]; then
+    printf 'synthetic %s list failure\n' "$resource" >&2
+    exit 35
+  fi
+  case "$resource" in
+    server) [ ! -f "$state/server_present" ] || printf '100   demo-control-plane\n' ;;
+    network) [ ! -f "$state/network_present" ] || printf '150   demo-network\n' ;;
+    firewall) [ ! -f "$state/firewall_present" ] || printf '200   unrelated-firewall\n' ;;
+    volume)
+      [ ! -f "$state/volume_present" ] || printf '300   data-volume   100\n'
+      [ ! -f "$state/detached_volume_present" ] || printf '301   detached-volume   -\n'
+      ;;
+    image) [ ! -f "$state/snapshot_present" ] || printf '400   legacy-snapshot   purpose=test\n' ;;
+    *) printf '\n' ;;
+  esac
+  exit 0
+fi
+
+if [ "$resource" = "volume" ] && [ "$action" = "delete" ] && [ -f "$state/server_present" ]; then
+  printf 'hcloud: volume is still attached to server\n' >&2
+  exit 37
+fi
+
+printf '%s\n' "$*" >> "$log"
+if [ "$action" = "delete" ]; then
+  case "$resource" in
+    server) rm -f "$state/server_present" ;;
+    network) rm -f "$state/network_present" ;;
+    firewall) rm -f "$state/firewall_present" ;;
+    volume)
+      [ "${3:-}" != "300" ] || rm -f "$state/volume_present"
+      [ "${3:-}" != "301" ] || rm -f "$state/detached_volume_present"
+      ;;
+    image) rm -f "$state/snapshot_present" ;;
+  esac
+fi
+FAKE_HCLOUD
+chmod +x "$fake_bin/hcloud"
+
+correct_token='correct-token-for-cleanup-tests-1234567890'
+wrong_token='wrong-token-for-cleanup-tests-123456789012'
+printf '%s' wrong > "$fake_state/active"
+printf '%s' "$wrong_token" > "$fake_state/contexts/wrong"
+touch "$fake_state/server_present" "$fake_state/network_present" "$fake_state/firewall_present"
+touch "$fake_state/volume_present" "$fake_state/detached_volume_present" "$fake_state/snapshot_present"
+cat > "$fake_config" <<EOF
+active_context = "wrong"
+
+[[contexts]]
+  name = "wrong"
+  token = "$wrong_token"
+EOF
+cat > "$root/kube.tf" <<'EOF'
+module "kube_hetzner" {
+  cluster_name = "demo"
+}
+EOF
+cat > "$root/terraform.tfvars" <<EOF
+hcloud_token = "$correct_token"
+EOF
+cat > "$root/custom.tfvars.json" <<EOF
+{
+  "hcloud_token": "$correct_token"
+}
+EOF
+cat > "$root/common.tfvars" <<'EOF'
+deployment_environment = "test"
+EOF
+
+export HOME="$fake_home"
+export PATH="$fake_bin:$PATH"
+export HCLOUD_CONFIG="$fake_config"
+export HCLOUD_TOKEN='poisoned-ambient-token-must-not-be-used'
+export HCLOUD_ENDPOINT='https://attacker.invalid/v1'
+export HETZNER_ENDPOINT='https://attacker.invalid/hetzner/v1'
+export HCLOUD_DEBUG=1
+export HCLOUD_DEBUG_FILE="$tmp/poisoned-debug.log"
+export HCLOUD_QUIET=1
+export HCLOUD_POLL_INTERVAL=1h
+export TF_VAR_hcloud_token="$wrong_token"
+export FAKE_HCLOUD_STATE="$fake_state"
+export FAKE_HCLOUD_LOG="$tmp/hcloud.log"
+export FAKE_EXPECTED_HCLOUD_TOKEN="$correct_token"
+: > "$FAKE_HCLOUD_LOG"
+
+"$cleanup_script" --help > "$tmp/help.log"
+grep -Fq -- '--execute' "$tmp/help.log"
+grep -Fq -- '--var-file' "$tmp/help.log"
+grep -Fq -- '--include-all-persistent' "$tmp/help.log"
+
+if (
+  cd "$root"
+  FAKE_HCLOUD_VERSION=1.58.0 "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/old-hcloud.log" 2>&1; then
+  echo 'cleanup accepted an unsupported hcloud version' >&2
+  exit 1
+fi
+grep -Fq 'hcloud >= 1.59.0 is required; found 1.58.0' "$tmp/old-hcloud.log"
+
+(
+  cd "$root"
+  "$cleanup_script" --cluster demo --var-file common.tfvars --var-file custom.tfvars.json --dry-run --yes
+) > "$tmp/dry-run.log"
+
+grep -Fq "Created hcloud context 'demo' from custom.tfvars.json (--var-file)." "$tmp/dry-run.log"
+grep -Fq 'Context:  demo (active)' "$tmp/dry-run.log"
+grep -Fq '100   demo-control-plane' "$tmp/dry-run.log"
+grep -Fq '200   unrelated-firewall' "$tmp/dry-run.log"
+grep -Fq '400   legacy-snapshot' "$tmp/dry-run.log"
+grep -Fq 'Token:    custom.tfvars.json (--var-file)' "$tmp/dry-run.log"
+grep -Fq 'including unrelated or unlabeled resources' "$tmp/dry-run.log"
+grep -Fq 'Dry run complete. Nothing was deleted.' "$tmp/dry-run.log"
+if grep -Eq '^Delete ' "$tmp/dry-run.log"; then
+  echo 'dry run executed a deletion' >&2
+  exit 1
+fi
+if grep -Eq 'Delete [^ ]+ +$|not found: *$' "$tmp/dry-run.log"; then
+  echo 'empty hcloud output became a fake resource' >&2
+  exit 1
+fi
+[ "$(cat "$fake_state/active")" = demo ]
+[ "$(cat "$fake_state/contexts/demo")" = "$correct_token" ]
+
+: > "$FAKE_HCLOUD_LOG"
+if (
+  cd "$root"
+  "$cleanup_script" --cluster demo --execute
+) > "$tmp/noninteractive-confirmation.log" 2>&1; then
+  echo 'non-interactive execute did not require --yes' >&2
+  exit 1
+fi
+grep -Fq -- '--execute in a non-interactive shell requires --yes' "$tmp/noninteractive-confirmation.log"
+if grep -Eq '(^| )delete( |$)' "$FAKE_HCLOUD_LOG"; then
+  echo 'cleanup mutated resources before non-interactive confirmation' >&2
+  exit 1
+fi
+
+: > "$FAKE_HCLOUD_LOG"
+(
+  cd "$root"
+  "$cleanup_script" --cluster demo --execute --yes
+) > "$tmp/execute.log"
+grep -Fq 'server disable-protection 100 delete' "$FAKE_HCLOUD_LOG"
+grep -Fq 'server delete 100' "$FAKE_HCLOUD_LOG"
+grep -Fq 'network disable-protection 150 delete' "$FAKE_HCLOUD_LOG"
+grep -Fq 'firewall delete 200' "$FAKE_HCLOUD_LOG"
+grep -Fq 'No selected resources remain.' "$tmp/execute.log"
+grep -Fq 'Cleanup completed in context demo.' "$tmp/execute.log"
+
+: > "$FAKE_HCLOUD_LOG"
+pty_execute="cd '$root' && exec '$cleanup_script' --cluster demo --execute --yes"
+pty_status=0
+if script --version >/dev/null 2>&1; then
+  script -q -e -c "$pty_execute" /dev/null </dev/null > "$tmp/pty-yes.log" || pty_status=$?
+else
+  script -q -e /dev/null /bin/bash -c "$pty_execute" </dev/null > "$tmp/pty-yes.log" || pty_status=$?
+fi
+if [ "$pty_status" -ne 0 ]; then
+  cat "$tmp/pty-yes.log" >&2
+  echo 'cleanup failed under a pseudo-terminal with --yes' >&2
+  exit 1
+fi
+grep -Fq 'Mode:                 EXECUTE' "$tmp/pty-yes.log"
+grep -Fq 'Cleanup completed in context demo.' "$tmp/pty-yes.log"
+if grep -Eq 'Execute deletion now|Delete all ' "$tmp/pty-yes.log"; then
+  echo '--yes prompted for persistent data in an interactive terminal' >&2
+  exit 1
+fi
+
+pty_dry_run="cd '$root' && exec '$cleanup_script' --cluster demo --yes"
+pty_status=0
+if script --version >/dev/null 2>&1; then
+  script -q -e -c "$pty_dry_run" /dev/null </dev/null > "$tmp/pty-dry-run.log" || pty_status=$?
+else
+  script -q -e /dev/null /bin/bash -c "$pty_dry_run" </dev/null > "$tmp/pty-dry-run.log" || pty_status=$?
+fi
+if [ "$pty_status" -ne 0 ]; then
+  cat "$tmp/pty-dry-run.log" >&2
+  echo 'cleanup failed to default to a dry run under --yes' >&2
+  exit 1
+fi
+grep -Fq 'Mode:                 DRY RUN' "$tmp/pty-dry-run.log"
+grep -Fq 'Dry run complete. Nothing was deleted.' "$tmp/pty-dry-run.log"
+if grep -Eq 'Execute deletion now|Delete all ' "$tmp/pty-dry-run.log"; then
+  echo '--yes prompted under a pseudo-terminal without an explicit mode' >&2
+  exit 1
+fi
+
+: > "$FAKE_HCLOUD_LOG"
+touch "$fake_state/server_present"
+(
+  cd "$root"
+  "$cleanup_script" --cluster demo --execute --include-volumes --include-snapshots --yes
+) > "$tmp/persistent-delete.log"
+grep -Fq 'volume delete 300' "$FAKE_HCLOUD_LOG"
+grep -Fq 'volume delete 301' "$FAKE_HCLOUD_LOG"
+server_delete_line=$(grep -nF 'server delete 100' "$FAKE_HCLOUD_LOG" | cut -d: -f1)
+volume_delete_line=$(grep -nF 'volume delete 300' "$FAKE_HCLOUD_LOG" | cut -d: -f1)
+[ "$server_delete_line" -lt "$volume_delete_line" ] || {
+  echo 'cleanup must delete servers before their attached volumes' >&2
+  exit 1
+}
+grep -Fq 'image disable-protection 400 delete' "$FAKE_HCLOUD_LOG"
+grep -Fq 'image delete 400' "$FAKE_HCLOUD_LOG"
+grep -Fq 'No selected resources remain.' "$tmp/persistent-delete.log"
+
+printf '%s' "$wrong_token" > "$fake_state/contexts/demo"
+cat > "$fake_config" <<EOF
+active_context = "demo"
+
+[[contexts]]
+  name = "demo"
+  token = "$wrong_token"
+EOF
+: > "$FAKE_HCLOUD_LOG"
+(
+  cd "$root"
+  "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/replaced-context.log" 2>&1
+grep -Fq "Context 'demo' exists with a different token" "$tmp/replaced-context.log" || {
+  cat "$tmp/replaced-context.log" >&2
+  printf '%s\n' 'contexts seen by fake hcloud:' >&2
+  env -u HCLOUD_TOKEN -u HCLOUD_CONTEXT -u HCLOUD_ENDPOINT -u HETZNER_ENDPOINT \
+    -u HCLOUD_DEBUG -u HCLOUD_DEBUG_FILE -u HCLOUD_QUIET -u HCLOUD_POLL_INTERVAL \
+    hcloud --debug=false --debug-file="" --quiet=false --poll-interval 500ms context list \
+    -o noheader -o 'columns=name' >&2 || true
+  echo 'cleanup did not detect a mismatched named context' >&2
+  exit 1
+}
+grep -Fq 'context rename demo demo-previous-' "$FAKE_HCLOUD_LOG"
+[ "$(cat "$fake_state/contexts/demo")" = "$correct_token" ]
+
+source_roots="$tmp/token-source-roots"
+mkdir -p "$source_roots/hcl-comment" "$source_roots/auto-order" "$source_roots/symlink-auto" \
+  "$source_roots/default-json" "$source_roots/unparsed"
+for source_root in "$source_roots"/*; do
+  cp "$root/kube.tf" "$source_root/kube.tf"
+done
+
+printf 'hcloud_token = "%s" // production project\n' "$correct_token" > "$source_roots/hcl-comment/terraform.tfvars"
+(
+  cd "$source_roots/hcl-comment"
+  "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/hcl-comment.log"
+grep -Fq 'Token:    terraform.tfvars' "$tmp/hcl-comment.log"
+
+printf 'hcloud_token = "%s"\n' "$wrong_token" > "$source_roots/auto-order/10.auto.tfvars"
+printf '{"hcloud_token":"%s"}\n' "$correct_token" > "$source_roots/auto-order/20.auto.tfvars.json"
+(
+  cd "$source_roots/auto-order"
+  "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/auto-order.log"
+grep -Fq 'Token:    20.auto.tfvars.json' "$tmp/auto-order.log"
+
+printf 'hcloud_token = "%s"\n' "$correct_token" > "$tmp/symlink-secret.tfvars"
+ln -s "$tmp/symlink-secret.tfvars" "$source_roots/symlink-auto/30.auto.tfvars"
+(
+  cd "$source_roots/symlink-auto"
+  "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/symlink-auto.log"
+grep -Fq 'Token:    30.auto.tfvars' "$tmp/symlink-auto.log"
+
+printf '{\n  "hcloud_token": "%s"\n}\n' "$correct_token" > "$source_roots/default-json/terraform.tfvars.json"
+(
+  cd "$source_roots/default-json"
+  "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/default-json.log"
+grep -Fq 'Token:    terraform.tfvars.json' "$tmp/default-json.log"
+
+printf 'hcloud_token = trimspace("%s")\n' "$correct_token" > "$source_roots/unparsed/terraform.tfvars"
+if (
+  cd "$source_roots/unparsed"
+  "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/unparsed-token.log" 2>&1; then
+  echo 'cleanup fell back after finding an unparsed higher-precedence token' >&2
+  exit 1
+fi
+grep -Fq 'highest-precedence hcloud_token assignment in terraform.tfvars is not a literal string' "$tmp/unparsed-token.log"
+
+: > "$FAKE_HCLOUD_LOG"
+(
+  cd "$root"
+  FAKE_HCLOUD_FAIL_RESOURCE=zone "$cleanup_script" --cluster demo --dry-run --yes
+) > "$tmp/optional-list-failure.log" 2>&1
+grep -Fq 'DNS zones could not be inventoried; they will remain untouched.' "$tmp/optional-list-failure.log"
+
+: > "$FAKE_HCLOUD_LOG"
+if (
+  cd "$root"
+  FAKE_HCLOUD_FAIL_RESOURCE=zone "$cleanup_script" --cluster demo --execute --include-dns-zones --yes
+) > "$tmp/selected-list-failure.log" 2>&1; then
+  echo 'cleanup accepted deletion of a persistent class it could not inventory' >&2
+  exit 1
+fi
+grep -Fq 'DNS zone deletion was requested, but DNS zones could not be inventoried.' "$tmp/selected-list-failure.log"
+if grep -Eq '(^| )delete( |$)' "$FAKE_HCLOUD_LOG"; then
+  echo 'cleanup mutated resources after a selected persistent inventory failed' >&2
+  exit 1
+fi
+
+: > "$FAKE_HCLOUD_LOG"
+if (
+  cd "$root"
+  FAKE_HCLOUD_FAIL_RESOURCE=network "$cleanup_script" --cluster demo --execute --yes
+) > "$tmp/list-failure.log" 2>&1; then
+  echo 'cleanup accepted a failed resource inventory' >&2
+  exit 1
+fi
+grep -Fq 'failed to list networks in context demo. No deletion was attempted.' "$tmp/list-failure.log"
+if grep -Eq '(^| )delete( |$)' "$FAKE_HCLOUD_LOG"; then
+  echo 'cleanup mutated resources after a failed inventory' >&2
+  exit 1
+fi
+
+echo 'PASS: cleanup pins the Terraform token, activates its exact context, inventories project-wide resources, and fails closed.'


### PR DESCRIPTION
## Summary

- make cleanupkh resolve and pin the Terraform HCloud project and cluster-named context
- default to a reviewable dry run, include all runtime leftovers, and require explicit opt-in for persistent data
- handle delete protection, empty CLI rows, post-delete verification, and the destroy-only ingress SSH timeout
- add regression coverage for credential, context, endpoint, parsing, and shell portability cases

## Verification

- cleanup regression suite and ShellCheck pass
- Terraform fmt, init, validate, OpenTofu validation, and example parsing pass
- kube-test `terraform init -upgrade` and plan pass: 53 create, 8 read, 0 change/destroy/replace in its empty test state
- real HCloud `test13` dry run completed without deleting resources; unrelated project resources were preserved

This is a maintainer fix for the cleanup path; no contributor PR is being superseded.