### PR TITLE
docs: finalize v3.2.0 release documentation

### DIFF
--- a/.claude/skills/kh-assistant/SKILL.md
+++ b/.claude/skills/kh-assistant/SKILL.md
@@ -116,7 +116,7 @@ grep 'variable "<name>"' variables.tf
 
 ### Current v3 Baseline
 
-Verify the live tag at startup; the checked-in release baseline is **v3.1.0**.
+Verify the live tag at startup; the checked-in release baseline is **v3.2.0**.
 
 | Fact | Current contract |
 |------|------------------|

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [3.2.0] - 2026-08-31
+
 ### ⚠️ Upgrade Notes
 
 - **Force cleanup scope and timeout:** `cleanupkh` now treats the HCloud project selected by the Terraform token as dedicated to one cluster and proposes deleting every runtime resource in that project, including unrelated resources. It defaults to a dry run; persistent data remains opt-in. Existing v3.1.0 K3s and RKE2 clusters also show an expected in-place update to the ingress load balancer destroy-cleanup `terraform_data` on the next apply. That apply must persist the new 45-second SSH timeout before a later destroy can use it.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A highly optimized, easy-to-operate Kubernetes cluster powered by k3s or RKE2 on
 - **Plan-time guardrails:** invalid topology and cross-variable combinations fail before infrastructure is created.
 - **Evidence-backed releases:** release claims are tied to live apply, upgrade, health, and destroy evidence in [`docs/v3-release-evidence.md`](docs/v3-release-evidence.md).
 
-**Current release:** [v3.1.0 release notes](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/releases/tag/v3.1.0) | [Changelog](CHANGELOG.md) | [v2 to v3 migration](MIGRATION.md)
+**Current release:** [v3.2.0 release notes](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/releases/tag/v3.2.0) | [Changelog](CHANGELOG.md) | [3.x upgrade guide](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/2232) | [v2 to v3 migration](MIGRATION.md)
 
 ## Quick Start
 

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -84,7 +84,7 @@ module "kube-hetzner" {
   source = "kube-hetzner/kube-hetzner/hcloud"
   #    When using the terraform registry as source, you can optionally specify a version number.
   #    See https://registry.terraform.io/modules/kube-hetzner/kube-hetzner/hcloud for the available versions
-  # version = "3.1.0"
+  # version = "3.2.0"
   # 2. For local dev, path to the git repo
   # source = "../../kube-hetzner/"
   # 3. If you want to use the latest main branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use
@@ -95,7 +95,7 @@ module "kube-hetzner" {
   * **Purpose:** This tells Terraform where to find the `kube-hetzner` module code.
   * **Option 1 (Terraform Registry - Recommended for Users):** `kube-hetzner/kube-hetzner/hcloud`
     * This is the standard way to use published modules. Terraform will download it from the public Terraform Registry.
-    * **`version`:** It's highly recommended to pin the module version (e.g., `version = "3.1.0"`). This ensures:
+    * **`version`:** It's highly recommended to pin the module version (e.g., `version = "3.2.0"`). This ensures:
       * **Reproducibility:** Your infrastructure builds are consistent over time.
       * **Stability:** Prevents unexpected changes or breakages if a new, incompatible version of the module is released.
       * **Controlled Upgrades:** You can consciously decide when to upgrade the module version after reviewing its changelog.
@@ -103,7 +103,7 @@ module "kube-hetzner" {
     * Used when you have a local copy of the module's source code, typically for development or testing modifications to the module itself. The path is relative to this `main.tf` file.
   * **Option 3 (Direct Git Repository - For Bleeding Edge/Specific Commits):** `source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner"`
     * Pulls the module directly from the `master` branch of the GitHub repository. This is generally **not recommended for production** as `master` can be unstable.
-    * You can also specify a specific branch, tag, or commit hash using the `ref` query parameter (e.g., `source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner?ref=v3.1.0"`).
+    * You can also specify a specific branch, tag, or commit hash using the `ref` query parameter (e.g., `source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner?ref=v3.2.0"`).
 
 ```terraform
   # Note that some values, notably "location" and "public_key" have no effect after initializing the cluster.

--- a/docs/v2-to-v3-migration.md
+++ b/docs/v2-to-v3-migration.md
@@ -319,7 +319,7 @@ Pin the module to the target v3 tag:
 ```hcl
 module "kube-hetzner" {
   source  = "kube-hetzner/kube-hetzner/hcloud"
-  version = "3.1.0"
+  version = "3.2.0"
 }
 ```
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -29,7 +29,7 @@ module "kube-hetzner" {
   source = "kube-hetzner/kube-hetzner/hcloud"
   #    When using the terraform registry as source, you can optionally specify a version number.
   #    See https://registry.terraform.io/modules/kube-hetzner/kube-hetzner/hcloud for the available versions
-  # version = "3.1.0"
+  # version = "3.2.0"
   # 2. For local dev, path to the git repo
   # source = "../../kube-hetzner/"
   # 3. If you want to use the latest main branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use


### PR DESCRIPTION
## Summary

- cut the published v3.2.0 notes out of `[Unreleased]`
- refresh current-release examples and assistant baseline to v3.2.0
- link the generic 3.x upgrade guide from the README

## Verification

- `terraform fmt -recursive`
- `terraform-docs markdown table --config .terraform-docs.yml --output-mode inject --output-file docs/terraform.md .`
- `bash scripts/tests/test_generated_site_contract.sh`
- `bash scripts/tests/test_release_workflow_contract.sh`
- `uv run scripts/validate_v3_final_polish_examples.py`
- `git diff --check`

Issue #2232 was updated directly with the generic 3.x guide.