### PR TITLE
docs: archive v3.2.1 release notes and refresh version links

### DIFF
--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -258,8 +258,42 @@ Before completing ANY issue:
 ## After Completion
 
 1. Create PR referencing the issue
-2. Request review if needed
-3. Close issue with explanation when merged
+2. Complete independent review and action automated Codex findings using `review-pr`
+3. Verify merge and the issue's actual resolution before closing with an explanation
+
+## End-to-End Issue Ownership
+
+For an authorized issue/PR intake, the investigating agent owns follow-through:
+investigation, a fix when justified, tests, useful contributor guidance, and the
+verified GitHub disposition. Reuse that agent for the reply and closure rather
+than having the coordinator post a second generic summary. The coordinator
+owns integration, release gates, and reconciliation of the evidence ledger.
+
+For each issue:
+1. Read the report, every comment, related PRs and earlier attempts; independently
+   check the relevant source and reproduce the failure where practical.
+2. Attempt the smallest safe fix when the cause is established. If no safe fix
+   is ready, record what was tested or ruled out, the remaining failure path,
+   and the exact next experiment or missing evidence. Deferral alone is not work.
+3. Provide concrete, sanitized diagnostics, recovery guidance or a verified
+   workaround where possible. State its limits; never ask someone to risk a
+   working cluster to reproduce a destructive transition.
+4. Record separate states: investigated, reproduced, guidance provided,
+   safeguard/partial fix, full fix, tests performed, merged, released, closed.
+   A proposed design is not an attempted implementation; a tested warning is
+   not a runtime repair; passing generic deploys does not prove that issue's
+   scenario. Report counts and remaining defects explicitly before release.
+5. Close as completed only when the reported problem is resolved. A warning,
+   auditor check or documentation mitigation does not close an underlying
+   runtime defect. Duplicates, support and rejected requests need an honest
+   reason and useful explanation, not a false claim that code was fixed.
+6. Read existing maintainer comments, update the relevant one instead of posting
+   a near-duplicate, thank human contributors naturally, and verify every write
+   and closure by readback. Leave routine bot PRs silent.
+
+Example: blocking unsafe network detachment in a plan auditor is a completed
+safeguard, but the attachment-migration issue stays open until the migration
+itself preserves networking. State both facts in the issue and release report.
 
 ## Community Communication
 

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -206,7 +206,7 @@ git add <specific-files>
 git commit -m "$(cat <<'EOF'
 fix: <brief description>
 
-Fixes #<number>
+Refs #<number>
 
 <explanation of what was wrong and how it's fixed>
 EOF
@@ -256,6 +256,12 @@ Before completing ANY issue:
 | Push | `git push -u origin <branch>` |
 
 ## After Completion
+
+Use non-closing `Refs #<number>` references by default in commits and PR
+descriptions. Reserve `Fixes`, `Closes` or `Resolves` keywords for verified full
+resolution: GitHub can close the issue automatically on merge, before an agent
+performs the manual closure check. Never use closing keywords for safeguards,
+diagnostic improvements or partial fixes to an unresolved runtime issue.
 
 1. Create PR referencing the issue
 2. Complete independent review and action automated Codex findings using `review-pr`

--- a/.claude/skills/kh-assistant/SKILL.md
+++ b/.claude/skills/kh-assistant/SKILL.md
@@ -116,7 +116,7 @@ grep 'variable "<name>"' variables.tf
 
 ### Current v3 Baseline
 
-Verify the live tag at startup; the checked-in release baseline is **v3.2.0**.
+Verify the live tag at startup; the checked-in release baseline is **v3.2.1**.
 
 | Fact | Current contract |
 |------|------------------|

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -465,6 +465,8 @@ Files that may need version updates:
 | `CHANGELOG.md` | Release content must stay under `[Unreleased]` until tag publication runs |
 | `docs/llms.md` | Example version references |
 | `kube.tf.example` | Version in comments |
+| `docs/v2-to-v3-migration.md` | Target module version in the migration example |
+| `.claude/skills/kh-assistant/SKILL.md` | Checked-in current release baseline (still verify live at startup) |
 | `.claude/skills/*/SKILL.md` | Operator workflows, v3 migration names, validation gates |
 | GPT knowledge | meta.version |
 

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -67,12 +67,13 @@ Therefore:
 
 GitHub-generated notes and the changelog expose the people whose work landed since the previous tag. Original PR submitters MUST remain visible — credit where credit is due.
 
-- Upstream requirement (enforced at merge time, see the `review-pr` skill): community contributions keep the contributor as commit **author** in master history. Squash only when merging a contributor-only PR directly; use a merge commit when we pushed fixes on top; cherry-pick with preserved authorship or `Co-authored-by:` trailers only when partially adopting or porting work.
+- Upstream requirement (enforced at merge time, see the `review-pr` skill): merge every accepted community PR's exact head into our isolated integration worktree first, then add maintainer adaptations in separate commits. Promote with merge commits, never squash or rebase, so original authorship and PR identity survive. Partial adoption or porting follows the skill's explicit credit and honest-closure rules.
 - Promotion or major integration PRs, such as the v3 staging-to-master train,
   must merge with a merge commit. Never squash those PRs; squashing erases the
   per-commit community authors that feed repository and release credit.
 - Pre-tag check: `git log <prev-tag>..HEAD --format='%an <%ae>' | sort -u` — every community contributor whose fix is in the release must be listed. If someone is missing, fix history/credit BEFORE tagging (after tagging it is public and immutable).
 - Pre-tag disposition check: every fully accepted community PR must have a non-null `mergedAt`. For PRs integrated indirectly through a release branch, also verify the recorded `headRefOid` is an ancestor of the release target. A closed-but-unmerged accepted PR is a release-process defect; repair the integration before tagging instead of compensating with comments.
+- Pre-tag review check: inspect automated Codex reviews and threads for each original and integration PR, action every finding, and verify the final-head disposition using `review-pr`. Green CI does not substitute for reading review feedback.
 - Post-release check: generated notes and changelog thanks must include the original submitters, not just maintainers. If someone is missing, treat it as a release defect and edit the release body.
 - Changelog entries for community fixes reference their PR/issue numbers so the human credit is also visible in prose.
 

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -53,7 +53,7 @@ Therefore:
 - Do not move `[Unreleased]` to `[vX.Y.Z] - YYYY-MM-DD` before tagging unless you are also bypassing the workflow and manually providing release notes.
 - Do not run `gh release create` during the normal path; the tag workflow owns publication. Use it only after re-running the local integrity gates if publication fails.
 - If Karim asks for a tiny release-prep correction during release, commit it on the release branch, merge it through the protected `master` pull-request path, then tag the resulting merged commit.
-- After a successful release, cut `CHANGELOG.md`: reset `## [Unreleased]` to an empty placeholder and move the released notes under `## [X.Y.Z] - YYYY-MM-DD`. Merge that cleanup through a release-maintenance pull request.
+- After a successful release, cut `CHANGELOG.md`: leave `## [Unreleased]` genuinely empty and move the released notes under `## [X.Y.Z] - YYYY-MM-DD`. Do not insert placeholder text or a separator before the next release heading: either would pass the publication workflow's non-whitespace guard. Merge that cleanup through a release-maintenance pull request.
 - Previous release notes must never remain under `## [Unreleased]`; otherwise the next tag workflow will publish stale notes again.
 - For v3-series releases, verify README's compact "Current release:" link points
   at the latest release tag and `CHANGELOG.md` carries the release content.
@@ -442,10 +442,6 @@ After confirming the live release, cut the changelog:
 
 ```markdown
 ## [Unreleased]
-
-_No unreleased changes._
-
----
 
 ## [X.Y.Z] - YYYY-MM-DD
 

--- a/.claude/skills/triage-issue/SKILL.md
+++ b/.claude/skills/triage-issue/SKILL.md
@@ -10,6 +10,13 @@ args: issue_number
 
 Analyze a GitHub issue, classify it, check for duplicates, and draft an appropriate response.
 
+During an authorized end-to-end intake, do not stop at classification or a
+draft. Follow `fix-issue`'s **End-to-End Issue Ownership** contract: the
+investigating agent advances the issue, provides specific help, and performs
+the verified comment/closure when appropriate. Distinguish investigation,
+partial safeguards and full fixes; unresolved runtime defects remain open.
+For an explicitly triage-only/read-only request, keep mutations out of scope.
+
 ## Usage
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-_No unreleased changes._
-
----
-
 ## [3.2.1] - 2026-09-09
 
 ### ⚠️ Upgrade Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes._
+
+---
+
+## [3.2.1] - 2026-09-09
+
 ### ⚠️ Upgrade Notes
 
 - The migration plan auditor now blocks standalone server-network detachment and flags in-place private/public networking changes. A plan with no server replacement is not sufficient proof of IP/MAC preservation, guest routing, or quorum-safe rollout. The underlying v2 attachment migration and existing-cluster NAT transitions still require separate operator review (#2277, #2283).

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A highly optimized, easy-to-operate Kubernetes cluster powered by k3s or RKE2 on
 - **Plan-time guardrails:** invalid topology and cross-variable combinations fail before infrastructure is created.
 - **Evidence-backed releases:** release claims are tied to live apply, upgrade, health, and destroy evidence in [`docs/v3-release-evidence.md`](docs/v3-release-evidence.md).
 
-**Current release:** [v3.2.0 release notes](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/releases/tag/v3.2.0) | [Changelog](CHANGELOG.md) | [3.x upgrade guide](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/2232) | [v2 to v3 migration](MIGRATION.md)
+**Current release:** [v3.2.1 release notes](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/releases/tag/v3.2.1) | [Changelog](CHANGELOG.md) | [3.x upgrade guide](https://github.com/kube-hetzner/terraform-hcloud-kube-hetzner/issues/2232) | [v2 to v3 migration](MIGRATION.md)
 
 ## Quick Start
 

--- a/docs/llms.md
+++ b/docs/llms.md
@@ -84,7 +84,7 @@ module "kube-hetzner" {
   source = "kube-hetzner/kube-hetzner/hcloud"
   #    When using the terraform registry as source, you can optionally specify a version number.
   #    See https://registry.terraform.io/modules/kube-hetzner/kube-hetzner/hcloud for the available versions
-  # version = "3.2.0"
+  # version = "3.2.1"
   # 2. For local dev, path to the git repo
   # source = "../../kube-hetzner/"
   # 3. If you want to use the latest main branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use
@@ -95,7 +95,7 @@ module "kube-hetzner" {
   * **Purpose:** This tells Terraform where to find the `kube-hetzner` module code.
   * **Option 1 (Terraform Registry - Recommended for Users):** `kube-hetzner/kube-hetzner/hcloud`
     * This is the standard way to use published modules. Terraform will download it from the public Terraform Registry.
-    * **`version`:** It's highly recommended to pin the module version (e.g., `version = "3.2.0"`). This ensures:
+    * **`version`:** It's highly recommended to pin the module version (e.g., `version = "3.2.1"`). This ensures:
       * **Reproducibility:** Your infrastructure builds are consistent over time.
       * **Stability:** Prevents unexpected changes or breakages if a new, incompatible version of the module is released.
       * **Controlled Upgrades:** You can consciously decide when to upgrade the module version after reviewing its changelog.
@@ -103,7 +103,7 @@ module "kube-hetzner" {
     * Used when you have a local copy of the module's source code, typically for development or testing modifications to the module itself. The path is relative to this `main.tf` file.
   * **Option 3 (Direct Git Repository - For Bleeding Edge/Specific Commits):** `source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner"`
     * Pulls the module directly from the `master` branch of the GitHub repository. This is generally **not recommended for production** as `master` can be unstable.
-    * You can also specify a specific branch, tag, or commit hash using the `ref` query parameter (e.g., `source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner?ref=v3.2.0"`).
+    * You can also specify a specific branch, tag, or commit hash using the `ref` query parameter (e.g., `source = "github.com/kube-hetzner/terraform-hcloud-kube-hetzner?ref=v3.2.1"`).
 
 ```terraform
   # Note that some values, notably "location" and "public_key" have no effect after initializing the cluster.

--- a/docs/v2-to-v3-migration.md
+++ b/docs/v2-to-v3-migration.md
@@ -321,7 +321,7 @@ Pin the module to the target v3 tag:
 ```hcl
 module "kube-hetzner" {
   source  = "kube-hetzner/kube-hetzner/hcloud"
-  version = "3.2.0"
+  version = "3.2.1"
 }
 ```
 

--- a/kube.tf.example
+++ b/kube.tf.example
@@ -29,7 +29,7 @@ module "kube-hetzner" {
   source = "kube-hetzner/kube-hetzner/hcloud"
   #    When using the terraform registry as source, you can optionally specify a version number.
   #    See https://registry.terraform.io/modules/kube-hetzner/kube-hetzner/hcloud for the available versions
-  # version = "3.2.0"
+  # version = "3.2.1"
   # 2. For local dev, path to the git repo
   # source = "../../kube-hetzner/"
   # 3. If you want to use the latest main branch (see https://developer.hashicorp.com/terraform/language/modules/sources#github), use


### PR DESCRIPTION
Post-publication maintenance only: DO NOT MERGE until v3.2.1 is successfully published from the preceding master commit. Preserve released notes byte-for-byte under the dated 3.2.1 heading, reset Unreleased, refresh the README/module examples, and align the release skill with mandatory history-preserving integration and automated Codex review triage. Independent review CLEAR at 56bc16e; notes preservation verified by comparison. Generated-site contract and v3 final-polish validation passed. No runtime change.